### PR TITLE
feat(ui): Add icons for newUI

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,8 @@
     </projectListeners>
 
     <extensions defaultExtensionNs="com.intellij">
+        <iconMapper
+                mappingFile="shadcnuiComponentsManagerIconMappings.json" />
         <toolWindow
                 id="shadcn/ui"
                 icon="/icons/shadcn.svg"

--- a/src/main/resources/icons/expUi/shadcn.svg
+++ b/src/main/resources/icons/expUi/shadcn.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="16" height="16">
+    <rect width="256" height="256" fill="none" />
+    <line x1="208" y1="128" x2="128" y2="208" fill="none" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+    <line x1="192" y1="40" x2="40" y2="192" fill="none" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+</svg>

--- a/src/main/resources/icons/expUi/shadcn@20x20.svg
+++ b/src/main/resources/icons/expUi/shadcn@20x20.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20">
+    <rect width="256" height="256" fill="none" />
+    <line x1="208" y1="128" x2="128" y2="208" fill="none" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+    <line x1="192" y1="40" x2="40" y2="192" fill="none" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+</svg>

--- a/src/main/resources/icons/expUi/shadcn@20x20_dark.svg
+++ b/src/main/resources/icons/expUi/shadcn@20x20_dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="20" height="20">
+    <rect width="256" height="256" fill="none" />
+    <line x1="208" y1="128" x2="128" y2="208" fill="none" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+    <line x1="192" y1="40" x2="40" y2="192" fill="none" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+</svg>

--- a/src/main/resources/icons/expUi/shadcn_dark.svg
+++ b/src/main/resources/icons/expUi/shadcn_dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="16" height="16">
+    <rect width="256" height="256" fill="none" />
+    <line x1="208" y1="128" x2="128" y2="208" fill="none" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+    <line x1="192" y1="40" x2="40" y2="192" fill="none" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" />
+</svg>

--- a/src/main/resources/shadcnuiComponentsManagerIconMappings.json
+++ b/src/main/resources/shadcnuiComponentsManagerIconMappings.json
@@ -1,0 +1,7 @@
+{
+  "icons": {
+    "expui": {
+      "shadcn.svg": "icons/shadcn.svg"
+    }
+  }
+}


### PR DESCRIPTION
To support IDEA's new UI since 2022.3, there are a [couple of steps](https://plugins.jetbrains.com/docs/intellij/icons.html#new-ui-icons) to follow to upgrade the plugin's icons.

However, despite the strict following of the docs, I cannot manage to have something working. If someone has a bit of time to lose and enough experience in that domain, I'm open to paths to figure out a working implementation.

With the current files of this PR, I can make the IDE use the new icons, however they are so small that they only appear as a dot in the tool windows' bar.

It's far from being high-priority, as the current "old" icons work very fine even on the new UI, so there is in theory no need to even update them, but still.