### PR TITLE
Fix tsconfig support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${libs.versions.serialization}")
 }
 
 // Set the JVM language level used to build the project.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${libs.versions.serialization}")
+    implementation(libs.serialization)
 }
 
 // Set the JVM language level used to build the project.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "1.9.23"
+serialization = "1.6.3"
 changelog = "2.2.0"
 gradleIntelliJPlugin = "1.17.3"
 qodana = "2023.3.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,9 @@ gradleIntelliJPlugin = "1.17.3"
 qodana = "2024.1.5"
 kover = "0.8.0"
 
+[libraries]
+serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
@@ -25,8 +25,8 @@ abstract class Source<C : Config>(val project: Project, private val serializer: 
     companion object {
         protected val tsConfigJson = Json {
             isLenient = true
-            allowTrailingCommas = true
-            allowComments = true
+//            allowTrailingCommas = true
+//            allowComments = true
         }
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
@@ -30,6 +30,11 @@ abstract class Source<C : Config>(val project: Project, private val serializer: 
                 log.debug("Parsed domain: $it")
             }
         }
+    protected val tsConfigJson = Json {
+        isLenient = true
+        allowTrailingCommas = true
+        allowComments = true
+    }
 
     // Utility methods
     protected fun getLocalConfig(): C {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
@@ -22,6 +22,14 @@ import java.net.URI
 import java.nio.file.NoSuchFileException
 
 abstract class Source<C : Config>(val project: Project, private val serializer: KSerializer<C>) {
+    companion object {
+        protected val tsConfigJson = Json {
+            isLenient = true
+            allowTrailingCommas = true
+            allowComments = true
+        }
+    }
+
     private val log = logger<Source<C>>()
     private var config: C? = null
 
@@ -31,11 +39,6 @@ abstract class Source<C : Config>(val project: Project, private val serializer: 
                 log.debug("Parsed domain: $it")
             }
         }
-    protected val tsConfigJson = Json {
-        isLenient = true
-        allowTrailingCommas = true
-        allowComments = true
-    }
 
     protected open val configFile = "components.json"
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
@@ -23,6 +23,7 @@ import java.nio.file.NoSuchFileException
 
 abstract class Source<C : Config>(val project: Project, private val serializer: KSerializer<C>) {
     companion object {
+        @JvmStatic
         protected val tsConfigJson = Json {
             isLenient = true
 //            allowTrailingCommas = true

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -13,9 +13,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.*
 import java.nio.file.NoSuchFileException
 
 open class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.serializer()) {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -39,7 +39,7 @@ open class ReactSource(project: Project) : Source<ReactConfig>(project, ReactCon
         val configFile = if (getLocalConfig().tsx) "tsconfig.json" else "jsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile)
             ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
+        val aliasPath = parseTsConfig(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -6,7 +6,6 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.Re
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.applyIf
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -26,7 +25,7 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
         }
         val configFile = if (getLocalConfig().tsx) "tsconfig.json" else "jsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile) ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = Json.parseToJsonElement(tsConfig)
+        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
@@ -10,9 +10,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.*
 import java.nio.file.NoSuchFileException
 
 open class SolidSource(project: Project) : Source<SolidConfig>(project, SolidConfig.serializer()) {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
@@ -44,7 +44,7 @@ open class SolidSource(project: Project) : Source<SolidConfig>(project, SolidCon
         val configFile = "tsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile)
             ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
+        val aliasPath = parseTsConfig(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
@@ -5,7 +5,6 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.SolidConfig
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -25,7 +24,7 @@ class SolidSource(project: Project) : Source<SolidConfig>(project, SolidConfig.s
         }
         val configFile = "tsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile) ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = Json.parseToJsonElement(tsConfig)
+        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
@@ -39,7 +39,7 @@ open class SolidUISource(project: Project) : Source<SolidUIConfig>(project, Soli
         val configFile = if (getLocalConfig().tsx) "tsconfig.json" else "jsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile)
             ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
+        val aliasPath = parseTsConfig(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -40,7 +39,7 @@ open class SolidUISource(project: Project) : Source<SolidUIConfig>(project, Soli
         val configFile = if (getLocalConfig().tsx) "tsconfig.json" else "jsconfig.json"
         val tsConfig = FileManager(project).getFileContentsAtPath(configFile)
             ?: throw NoSuchFileException("$configFile not found")
-        val aliasPath = Json.parseToJsonElement(tsConfig)
+        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -50,7 +50,7 @@ class SvelteSource(project: Project) : Source<SvelteConfig>(project, SvelteConfi
             tsConfig =
                 fileManager.getFileContentsAtPath(configFile) ?: throw NoSuchFileException("Cannot get $configFile")
         }
-        val aliasPath = Json.parseToJsonElement(tsConfig)
+        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get(alias.substringBefore("/"))

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -57,7 +57,7 @@ open class SvelteSource(project: Project) : Source<SvelteConfig>(project, Svelte
             tsConfig =
                 fileManager.getFileContentsAtPath(configFile) ?: throw NoSuchFileException("Cannot get $configFile")
         }
-        val aliasPath = tsConfigJson.parseToJsonElement(tsConfig)
+        val aliasPath = parseTsConfig(tsConfig)
             .jsonObject["compilerOptions"]
             ?.jsonObject?.get("paths")
             ?.jsonObject?.get(alias.substringBefore("/"))

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
@@ -38,7 +38,7 @@ open class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.se
         }
 
         fun resolvePath(configFile: String): String? {
-            return tsConfigJson.parseToJsonElement(configFile)
+            return parseTsConfig(configFile)
                 .jsonObject["compilerOptions"]
                 ?.jsonObject?.get("paths")
                 ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
@@ -13,9 +13,7 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.*
 import java.nio.file.NoSuchFileException
 
 open class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.serializer()) {
@@ -40,11 +38,7 @@ open class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.se
         }
 
         fun resolvePath(configFile: String): String? {
-            return tsConfigJson.parseToJsonElement(configFile
-                .split("\n")
-                .filterNot { it.trim().startsWith("//") } // remove comments
-                .joinToString("\n")
-            )
+            return tsConfigJson.parseToJsonElement(configFile)
                 .jsonObject["compilerOptions"]
                 ?.jsonObject?.get("paths")
                 ?.jsonObject?.get("${alias.substringBefore("/")}/*")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
@@ -9,7 +9,6 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.applyIf
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -29,7 +28,7 @@ class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.seriali
         }
 
         fun resolvePath(configFile: String): String? {
-            return Json.parseToJsonElement(configFile
+            return tsConfigJson.parseToJsonElement(configFile
                 .split("\n")
                 .filterNot { it.trim().startsWith("//") } // remove comments
                 .joinToString("\n")


### PR DESCRIPTION
Fixes #32.

Widen tolerance of the Json constructor to allow [JSON5 features](https://spec.json5.org/#summary-of-features), unlocking support for `tsconfig.json` files with comments (and more).

~~Waiting for a release including https://github.com/Kotlin/kotlinx.serialization/pull/2592 to merge.~~