### PR TITLE
Rewrite the Tailwind classes replacement & imports replacement engines, update configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Changed
 
-- Entirely rework the Tailwind classes replacement engine to be more accurate and faster
+- Entirely rewrite the Tailwind classes replacement engine to be more accurate and faster
     - Consequently, the plugin now depends
       on [Svelte](https://plugins.jetbrains.com/plugin/12375-svelte) & [Vue](https://plugins.jetbrains.com/plugin/9442-vue-js)
       extensions and only works on WebStorm or IntelliJ IDEA Ultimate
@@ -87,19 +87,11 @@
 - Initial release
 
 [Unreleased]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.7...HEAD
-
 [0.7.7]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.6...v0.7.7
-
 [0.7.6]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.5...v0.7.6
-
 [0.7.5]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.4...v0.7.5
-
 [0.7.4]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.3...v0.7.4
-
 [0.7.3]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.2...v0.7.3
-
 [0.7.2]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.1...v0.7.2
-
 [0.7.1]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.0...v0.7.1
-
 [0.7.0]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Entirely rework the Tailwind classes replacement engine to be more accurate and faster
+    - Consequently, the plugin now depends
+      on [Svelte](https://plugins.jetbrains.com/plugin/12375-svelte) & [Vue](https://plugins.jetbrains.com/plugin/9442-vue-js)
+      extensions and only works on WebStorm or IntelliJ IDEA Ultimate
+
 ## [0.7.7] - 2024-03-29
 
 ### Changed
@@ -80,11 +87,19 @@
 - Initial release
 
 [Unreleased]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.7...HEAD
+
 [0.7.7]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.6...v0.7.7
+
 [0.7.6]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.5...v0.7.6
+
 [0.7.5]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.4...v0.7.5
+
 [0.7.4]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.3...v0.7.4
+
 [0.7.3]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/compare/v0.7.2...v0.7.3
+
 [0.7.2]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.1...v0.7.2
+
 [0.7.1]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.0...v0.7.1
+
 [0.7.0]: https://github.com/WarningImHack3r/intellij-shadcn-plugin/commits/v0.7.0

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 ## ToDo list before 1.0.0
 
-- Rework `class`es replacement detection mechanism to be 100% accurate
-  - Add tests for this
 - Add support for Vue `typescript` option (transpiling TypeScript to JavaScript as well as in `*.vue` files)
 
 ## Description
@@ -15,8 +13,10 @@
 <!-- Plugin description -->
 Manage your shadcn/ui components in your project. Supports Svelte, React, Vue, and Solid.
 
-This plugin will help you manage your shadcn/ui components through a simple tool window. Add, remove, update them with a single click.  
-**This plugin will only work with an existing `components.json` file. Manually copied components will not be detected otherwise.**
+This plugin will help you manage your shadcn/ui components through a simple tool window. Add, remove, update them with a
+single click.  
+**This plugin will only work with an existing `components.json` file. Manually copied components will not be detected
+otherwise.**
 
 ## Features
 
@@ -33,7 +33,8 @@ This plugin will help you manage your shadcn/ui components through a simple tool
 
 Simply open the `shadcn/ui` tool window and start managing your components.  
 If you don't see the tool window, you can open it from `View > Tool Windows > shadcn/ui`.  
-**When adding or removing components, the tool window won't refresh automatically yet. You can refresh it by closing and reopening it.**
+**When adding or removing components, the tool window won't refresh automatically yet. You can refresh it by closing and
+reopening it.**
 
 ## Planned Features
 
@@ -44,20 +45,22 @@ If you don't see the tool window, you can open it from `View > Tool Windows > sh
 - Figure out a clean way to refresh the tool window automatically after adding or removing components
 - Refresh/recreate the tool window automatically when the project finishes indexing
 - Add support for monorepos
+
 <!-- Plugin description end -->
 
 ## Installation
 
 - Using the IDE built-in plugin system:
-  
-  <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "intellij-shadcn-plugin"</kbd> >
+
+  <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Marketplace</kbd> > <kbd>Search for "
+  intellij-shadcn-plugin"</kbd> >
   <kbd>Install</kbd>
-  
+
 - Manually:
 
-  Download the [latest release](https://github.com/WarningImHack3r/intellij-shadcn-plugin/releases/latest) and install it manually using
+  Download the [latest release](https://github.com/WarningImHack3r/intellij-shadcn-plugin/releases/latest) and install
+  it manually using
   <kbd>Settings/Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>⚙️</kbd> > <kbd>Install plugin from disk...</kbd>
-
 
 ---
 Plugin based on the [IntelliJ Platform Plugin Template][template].

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 [![Version](https://img.shields.io/jetbrains/plugin/v/com.github.warningimhack3r.intellijshadcnplugin.svg)](https://plugins.jetbrains.com/plugin/com.github.warningimhack3r.intellijshadcnplugin)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.github.warningimhack3r.intellijshadcnplugin.svg)](https://plugins.jetbrains.com/plugin/com.github.warningimhack3r.intellijshadcnplugin)
 
-## ToDo list before 1.0.0
+## 1.0.0 roadmap
 
 - Add support for Vue `typescript` option (transpiling TypeScript to JavaScript as well as in `*.vue` files)
+  - See https://github.com/radix-vue/shadcn-vue/issues/378
 
 ## Description
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,19 +4,19 @@ pluginGroup = com.github.warningimhack3r.intellijshadcnplugin
 pluginName = intellij-shadcn-plugin
 pluginRepositoryUrl = https://github.com/WarningImHack3r/intellij-shadcn-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.7.7
+pluginVersion = 0.8.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
 pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-platformType = IC
+platformType = IU
 platformVersion = 2021.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =
+platformPlugins = JavaScript, dev.blachut.svelte.lang:0.21.1, org.jetbrains.plugins.vue:213.5744.223
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.6

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
@@ -2,7 +2,6 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.helpers
 
 import com.github.warningimhack3r.intellijshadcnplugin.notifications.NotificationManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import kotlinx.serialization.json.Json
@@ -22,9 +21,7 @@ class DependencyManager(private val project: Project) {
             "yarn.lock" to "yarn",
             "bun.lockb" to "bun"
         ).filter {
-            runReadAction {
-                fileManager.getVirtualFilesByName(it.key).isNotEmpty()
-            }
+            fileManager.getVirtualFilesByName(it.key).isNotEmpty()
         }.values.firstOrNull()
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/FileManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/FileManager.kt
@@ -1,5 +1,6 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.helpers
 
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -51,10 +52,12 @@ class FileManager(private val project: Project) {
             // a simple call to FilenameIndex.getVirtualFilesByName.
             // This is a dirty workaround to make it work on production,
             // because it works fine during local development.
-            FilenameIndex.getVirtualFilesByName(
-                "components.json",
-                GlobalSearchScope.projectScope(project)
-            ).firstOrNull().also {
+            runReadAction {
+                FilenameIndex.getVirtualFilesByName(
+                    "components.json",
+                    GlobalSearchScope.projectScope(project)
+                )
+            }.firstOrNull().also {
                 if (it == null) {
                     log.warn("components.json not found with the workaround")
                 }
@@ -64,10 +67,12 @@ class FileManager(private val project: Project) {
                 log.warn("No file named $name found with the workaround")
             }
         } else {
-            FilenameIndex.getVirtualFilesByName(
-                name,
-                GlobalSearchScope.projectScope(project)
-            )
+            runReadAction {
+                FilenameIndex.getVirtualFilesByName(
+                    name,
+                    GlobalSearchScope.projectScope(project)
+                )
+            }
         }).filter { file ->
             !file.path.contains("/node_modules/") && !file.path.contains("/.git/")
         }.sortedBy { file ->

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/PsiHelper.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/PsiHelper.kt
@@ -1,0 +1,34 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.helpers
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+
+object PsiHelper {
+
+    fun createPsiFile(project: Project, fileName: String, text: String): PsiFile {
+        assert(fileName.contains('.')) { "File name must contain an extension" }
+        return PsiFileFactory.getInstance(project).createFileFromText(
+            fileName, FileTypeManager.getInstance().getFileTypeByExtension(
+                fileName.substringAfterLast('.')
+            ), text
+        )
+    }
+
+    fun createPsiFile(project: Project, language: FileType, text: String): PsiFile {
+        return PsiFileFactory.getInstance(project).createFileFromText(
+            "temp.${language.defaultExtension}", language, text
+        )
+    }
+
+    fun writeAction(file: PsiFile, description: String? = null, action: () -> Unit) {
+        WriteCommandAction.runWriteCommandAction(
+            file.project, description,
+            "com.github.warningimhack3r.intellijshadcnplugin",
+            action, file
+        )
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/PsiHelper.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/PsiHelper.kt
@@ -1,7 +1,7 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.helpers
 
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
@@ -11,17 +11,13 @@ object PsiHelper {
 
     fun createPsiFile(project: Project, fileName: String, text: String): PsiFile {
         assert(fileName.contains('.')) { "File name must contain an extension" }
-        return PsiFileFactory.getInstance(project).createFileFromText(
-            fileName, FileTypeManager.getInstance().getFileTypeByExtension(
-                fileName.substringAfterLast('.')
-            ), text
-        )
-    }
-
-    fun createPsiFile(project: Project, language: FileType, text: String): PsiFile {
-        return PsiFileFactory.getInstance(project).createFileFromText(
-            "temp.${language.defaultExtension}", language, text
-        )
+        return runReadAction {
+            PsiFileFactory.getInstance(project).createFileFromText(
+                fileName, FileTypeManager.getInstance().getFileTypeByExtension(
+                    fileName.substringAfterLast('.')
+                ), text
+            )
+        }
     }
 
     fun writeAction(file: PsiFile, description: String? = null, action: () -> Unit) {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/Source.kt
@@ -97,6 +97,7 @@ abstract class Source<C : Config>(val project: Project, private val serializer: 
     }
 
     open fun addComponent(componentName: String) {
+        val config = getLocalConfig()
         // Install component
         val component = fetchComponent(componentName)
         val installedComponents = getInstalledComponents()
@@ -109,7 +110,7 @@ abstract class Source<C : Config>(val project: Project, private val serializer: 
             log.debug("Installing ${it.size} components: ${it.joinToString(", ") { component -> component.name }}")
         }.forEach { downloadedComponent ->
             val path =
-                "${resolveAlias(getLocalConfig().aliases.components)}/${component.type.substringAfterLast(":")}" + if (usesDirectoriesForComponents()) {
+                "${resolveAlias(config.aliases.components)}/${component.type.substringAfterLast(":")}" + if (usesDirectoriesForComponents()) {
                     "/${downloadedComponent.name}"
                 } else ""
             // Check for deprecated components

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
@@ -14,11 +14,11 @@ import kotlinx.serialization.Serializable
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
 class ReactConfig(
-    override val `$schema`: String,
+    override val `$schema`: String = "https://ui.shadcn.com/schema.json",
     override val style: String,
-    override val tailwind: Tailwind,
-    val rsc: Boolean,
+    val rsc: Boolean = false,
     val tsx: Boolean = true,
+    override val tailwind: Tailwind,
     override val aliases: Aliases
 ) : Config() {
 
@@ -35,7 +35,7 @@ class ReactConfig(
         override val config: String,
         override val css: String,
         override val baseColor: String,
-        val cssVariables: Boolean,
+        val cssVariables: Boolean = true,
         val prefix: String = ""
     ) : Config.Tailwind()
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
@@ -35,7 +35,7 @@ class ReactConfig(
         override val config: String,
         override val css: String,
         override val baseColor: String,
-        private val cssVariables: Boolean = true,
+        val cssVariables: Boolean = true,
         val prefix: String = ""
     ) : Config.Tailwind()
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/ReactConfig.kt
@@ -35,7 +35,7 @@ class ReactConfig(
         override val config: String,
         override val css: String,
         override val baseColor: String,
-        val cssVariables: Boolean = true,
+        private val cssVariables: Boolean = true,
         val prefix: String = ""
     ) : Config.Tailwind()
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidConfig.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
 class SolidConfig(
-    override val `$schema`: String,
+    override val `$schema`: String = "",
     override val style: String,
     override val tailwind: VueConfig.Tailwind,
     override val aliases: Aliases

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SvelteConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SvelteConfig.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.Serializable
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
 class SvelteConfig(
-    override val `$schema`: String,
+    override val `$schema`: String = "https://shadcn-svelte.com/schema.json",
     override val style: String,
     override val tailwind: Tailwind,
-    val typescript: Boolean = true,
-    override val aliases: Aliases
+    override val aliases: Aliases,
+    val typescript: Boolean = true
 ) : Config() {
 
     @Serializable

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/VueConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/VueConfig.kt
@@ -12,12 +12,13 @@ import kotlinx.serialization.Serializable
  * @param framework The Vue framework to use.
  * @param aliases The aliases for the components and utils directories.
  */
-@Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
+@Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117", "unused")
 @Serializable
 class VueConfig(
     override val `$schema`: String = "https://shadcn-vue.com/schema.json",
     override val style: String,
     val typescript: Boolean = true,
+    val tsConfigPath: String = "./tsconfig.json",
     override val tailwind: Tailwind,
     val framework: Framework = Framework.VITE,
     override val aliases: Aliases
@@ -35,7 +36,8 @@ class VueConfig(
         override val config: String,
         override val css: String,
         override val baseColor: String,
-        open val cssVariables: Boolean = true
+        val cssVariables: Boolean = true,
+        val prefix: String = ""
     ) : Config.Tailwind()
 
     /**
@@ -61,5 +63,6 @@ class VueConfig(
     class Aliases(
         override val components: String,
         override val utils: String,
+        val ui: String? = null
     ) : Config.Aliases()
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -73,7 +73,7 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
             `package`
         }
 
-        if (config.rsc) {
+        if (!config.rsc) {
             val directiveVisitor = ReactDirectiveRemovalVisitor(project) { directive ->
                 directive == "use client"
             }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -98,8 +98,11 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
             val modifier = if (`class`.contains(":")) `class`.substringBeforeLast(":") + ":" else ""
             val className = `class`.substringAfterLast(":")
             val twPrefix = config.tailwind.prefix
+            if (config.tailwind.cssVariables) {
+                return@replacer "$modifier$twPrefix$className"
+            }
             if (className == "border") {
-                return@replacer "${modifier}${twPrefix}border ${modifier}${twPrefix}border-border"
+                return@replacer "$modifier${twPrefix}border $modifier${twPrefix}border-border"
             }
             val prefix = prefixesToReplace.find { className.startsWith(it) }
                 ?: return@replacer "$modifier$twPrefix$className"

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/ReactSource.kt
@@ -1,10 +1,13 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.ReactConfig
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.JSXClassReplacementVisitor
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import com.intellij.util.applyIf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -48,7 +51,7 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
         } else extension
     }
 
-    override fun adaptFileToConfig(contents: String): String {
+    override fun adaptFileToConfig(file: PsiFile) {
         val config = getLocalConfig()
         // Note: this does not prevent additional imports other than "cn" from being replaced,
         // but I'm once again following what the original code does for parity
@@ -59,10 +62,10 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
             // For me, this is a bug, but I'm following what the original code does for parity
             // (https://github.com/shadcn-ui/ui/blob/fb614ac2921a84b916c56e9091aa0ae8e129c565/packages/cli/src/utils/transformers/transform-import.ts#L10-L23).
             if (config.aliases.ui != null) {
-                contents.replace(
+                file.text.replace(
                     Regex("@/registry/[^/]+/ui"), cleanAlias(config.aliases.ui)
                 )
-            } else contents.replace(
+            } else file.text.replace(
                 Regex("@/registry/[^/]+"), cleanAlias(config.aliases.components)
             )
         ) { result ->
@@ -72,111 +75,36 @@ class ReactSource(project: Project) : Source<ReactConfig>(project, ReactConfig.s
                 Regex("\"use client\";*\n"), ""
             )
         }
-
-        /**
-         * Prepends `tw-` to all Tailwind classes.
-         * @param classes The classes to prefix, an unquoted string of space-separated class names.
-         * @param prefix The prefix to add to each class name.
-         * @return The prefixed classes.
-         */
-        fun prefixClasses(classes: String, prefix: String): String = classes
-            .split(" ")
-            .filterNot { it.isEmpty() }
-            .joinToString(" ") {
-                val className = it.trim().split(":")
-                if (className.size == 1) {
-                    "$prefix${className[0]}"
-                } else {
-                    "${className.dropLast(1).joinToString(":")}:$prefix${className.last()}"
-                }
-            }
-
-        /**
-         * Converts CSS variables to Tailwind utility classes.
-         * @param classes The classes to convert, an unquoted string of space-separated class names.
-         * @param lightColors The light colors map to use.
-         * @param darkColors The dark colors map to use.
-         * @return The converted classes.
-         */
-        fun variablesToUtilities(
-            classes: String,
-            lightColors: Map<String, String>,
-            darkColors: Map<String, String>
-        ): String {
-            // Note: this does not include `border` classes at the beginning or end of the string,
-            // but I'm once again following what the original code does for parity
-            // (https://github.com/shadcn-ui/ui/blob/fb614ac2921a84b916c56e9091aa0ae8e129c565/packages/cli/src/utils/transformers/transform-css-vars.ts#L142-L145).
-            val newClasses = classes.replace(" border ", " border border-border ")
-
-            val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
-
-            /**
-             * Replaces a class with CSS variables with Tailwind utility classes.
-             * @param class The class to replace.
-             * @return The replaced class.
-             */
-            fun replaceClass(`class`: String): String {
-                val prefix = prefixesToReplace.find { `class`.startsWith(it) } ?: return `class`
-                val color = `class`.substringAfter(prefix)
-                val lightColor = lightColors[color]
-                val darkColor = darkColors[color]
-                return if (lightColor != null && darkColor != null) {
-                    "$prefix$lightColor dark:$prefix$darkColor"
-                } else `class`
-            }
-
-            return newClasses
-                .split(" ")
-                .filterNot { it.isEmpty() }
-                .joinToString(" ") {
-                    val className = it.trim().split(":")
-                    if (className.size == 1) {
-                        replaceClass(className[0])
-                    } else {
-                        "${className.dropLast(1).joinToString(":")}:${replaceClass(className.last())}"
-                    }
-                }
+        PsiHelper.writeAction(file, "Replacing imports") {
+            file.replace(PsiHelper.createPsiFile(project, file.fileType, newContents))
         }
 
-        fun handleClasses(classes: String): String {
-            var newClasses = classes
-            if (!config.tailwind.cssVariables) {
-                val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
-                    ?: throw Exception("Inline colors not found")
-                newClasses = variablesToUtilities(
-                    newClasses,
-                    inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
-                        lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap(),
-                    inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
-                        darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap()
-                )
-            }
-            if (config.tailwind.prefix.isNotEmpty()) {
-                newClasses = prefixClasses(newClasses, config.tailwind.prefix)
-            }
-            return newClasses
-        }
+        val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
 
-        return Regex("className=(?:(?!>)[^\"'])*[\"']([^>]*)[\"']").replace(newContents) { result ->
-            // matches any className, and takes everything inside the first quote to the last quote found before the closing `>`
-            // if no quotes are found before the closing `>`, skips the match
-            val match = result.groupValues[0]
-            val group = result.groupValues[1]
-            match.replace(
-                group,
-                // if the group contains a quote, we assume the classes are the last quoted string in the group
-                if (group.contains("\"")) {
-                    group.substringBeforeLast('"') + "\"" + handleClasses(
-                        group.substringAfterLast('"')
-                    )
-                } else if (group.contains("'")) {
-                    group.substringBeforeLast("'") + "'" + handleClasses(
-                        group.substringAfterLast("'")
-                    )
-                } else handleClasses(group)
-            )
-        }
+        val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
+            ?: throw Exception("Inline colors not found")
+        val lightColors = inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
+            lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
+        } ?: emptyMap()
+        val darkColors = inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
+            darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
+        } ?: emptyMap()
+
+        file.accept(JSXClassReplacementVisitor visitor@{ `class` ->
+            val modifier = if (`class`.contains(":")) `class`.substringBeforeLast(":") + ":" else ""
+            val className = `class`.substringAfterLast(":")
+            val twPrefix = config.tailwind.prefix
+            if (className == "border") {
+                return@visitor "${modifier}${twPrefix}border ${modifier}${twPrefix}border-border"
+            }
+            val prefix = prefixesToReplace.find { className.startsWith(it) }
+                ?: return@visitor "$modifier$twPrefix$className"
+            val color = className.substringAfter(prefix)
+            val lightColor = lightColors[color]
+            val darkColor = darkColors[color]
+            if (lightColor != null && darkColor != null) {
+                "$modifier$twPrefix$prefix$lightColor dark:$modifier$twPrefix$prefix$darkColor"
+            } else "$modifier$twPrefix$className"
+        })
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
@@ -1,10 +1,13 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.SolidConfig
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.JSXClassReplacementVisitor
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -39,98 +42,47 @@ class SolidSource(project: Project) : Source<SolidConfig>(project, SolidConfig.s
             }
     }
 
-    override fun adaptFileToConfig(contents: String): String {
+    override fun adaptFileToConfig(file: PsiFile) {
         val config = getLocalConfig()
         // Note: this does not prevent additional imports other than "cn" from being replaced,
         // but I'm following what the original code does for parity
         // (https://github.com/hngngn/shadcn-solid/blob/b808e0ecc9fd4689572d9fc0dfb7af81606a11f2/packages/cli/src/utils/transformers/transform-import.ts#L20-L29).
         val newContents = Regex(".*\\{.*[ ,\n\t]+cn[ ,].*}.*\"(@/lib/cn).*").replace(
-            contents.replace(
+            file.text.replace(
                 Regex("@/registry/[^/]+"), cleanAlias(config.aliases.components)
             )
         ) { it.groupValues[0].replace(it.groupValues[1], config.aliases.utils) }
+        PsiHelper.writeAction(file, "Replacing imports") {
+            file.replace(PsiHelper.createPsiFile(project, file.fileType, newContents))
+        }
 
-        return if (!config.tailwind.cssVariables) {
-            /**
-             * Converts CSS variables to Tailwind utility classes.
-             * @param classes The classes to convert, an unquoted string of space-separated class names.
-             * @param lightColors The light colors map to use.
-             * @param darkColors The dark colors map to use.
-             * @return The converted classes.
-             */
-            fun variablesToUtilities(
-                classes: String,
-                lightColors: Map<String, String>,
-                darkColors: Map<String, String>
-            ): String {
-                // Note: this does not include `border` classes at the beginning or end of the string,
-                // but I'm once again following what the original code does for parity
-                // (https://github.com/hngngn/shadcn-solid/blob/b808e0ecc9fd4689572d9fc0dfb7af81606a11f2/packages/cli/src/utils/transformers/transform-css-vars.ts#L144-L147).
-                val newClasses = classes.replace(" border ", " border border-border ")
+        if (!config.tailwind.cssVariables) {
+            val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
 
-                val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
+            val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
+                ?: throw Exception("Inline colors not found")
+            val lightColors = inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
+                lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
+            } ?: emptyMap()
+            val darkColors = inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
+                darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
+            } ?: emptyMap()
 
-                /**
-                 * Replaces a class with CSS variables with Tailwind utility classes.
-                 * @param class The class to replace.
-                 * @return The replaced class.
-                 */
-                fun replaceClass(`class`: String): String {
-                    val prefix = prefixesToReplace.find { `class`.startsWith(it) } ?: return `class`
-                    val color = `class`.substringAfter(prefix)
-                    val lightColor = lightColors[color]
-                    val darkColor = darkColors[color]
-                    return if (lightColor != null && darkColor != null) {
-                        "$prefix$lightColor dark:$prefix$darkColor"
-                    } else `class`
+            file.accept(JSXClassReplacementVisitor visitor@{ `class` ->
+                val modifier = if (`class`.contains(":")) `class`.substringBeforeLast(":") + ":" else ""
+                val className = `class`.substringAfterLast(":")
+                if (className == "border") {
+                    return@visitor "${modifier}border ${modifier}border-border"
                 }
-
-                return newClasses
-                    .split(" ")
-                    .filterNot { it.isEmpty() }
-                    .joinToString(" ") {
-                        val className = it.trim().split(":")
-                        if (className.size == 1) {
-                            replaceClass(className[0])
-                        } else {
-                            "${className.dropLast(1).joinToString(":")}:${replaceClass(className.last())}"
-                        }
-                    }
-            }
-
-            fun handleClasses(classes: String): String {
-                val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
-                    ?: throw Exception("Inline colors not found")
-                return variablesToUtilities(
-                    classes,
-                    inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
-                        lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap(),
-                    inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
-                        darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap()
-                )
-            }
-
-            Regex("className=(?:(?!>)[^\"'])*[\"']([^>]*)[\"']").replace(newContents) { result ->
-                // matches any className, and takes everything inside the first quote to the last quote found before the closing `>`
-                // if no quotes are found before the closing `>`, skips the match
-                val match = result.groupValues[0]
-                val group = result.groupValues[1]
-                match.replace(
-                    group,
-                    // if the group contains a quote, we assume the classes are the last quoted string in the group
-                    if (group.contains("\"")) {
-                        group.substringBeforeLast('"') + "\"" + handleClasses(
-                            group.substringAfterLast('"')
-                        )
-                    } else if (group.contains("'")) {
-                        group.substringBeforeLast("'") + "'" + handleClasses(
-                            group.substringAfterLast("'")
-                        )
-                    } else handleClasses(group)
-                )
-            }
-        } else newContents
+                val prefix = prefixesToReplace.find { className.startsWith(it) }
+                    ?: return@visitor "$modifier$className"
+                val color = className.substringAfter(prefix)
+                val lightColor = lightColors[color]
+                val darkColor = darkColors[color]
+                if (lightColor != null && darkColor != null) {
+                    "$modifier$prefix$lightColor dark:$modifier$prefix$darkColor"
+                } else "$modifier$className"
+            })
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -90,8 +90,8 @@ class SvelteSource(project: Project) : Source<SvelteConfig>(project, SvelteConfi
         runReadAction { file.accept(importsPackagesReplacementVisitor) }
         importsPackagesReplacementVisitor.replaceImports { `package` ->
             `package`
-                .replace(Regex("\\\$lib/registry/[^/]+"), config.aliases.components)
-                .replace("\$lib/utils", config.aliases.components)
+                .replace(Regex("^${"$"}lib/registry/[^/]+"), config.aliases.components)
+                .replace("\$lib/utils", config.aliases.utils)
         }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -90,7 +90,7 @@ class SvelteSource(project: Project) : Source<SvelteConfig>(project, SvelteConfi
         runReadAction { file.accept(importsPackagesReplacementVisitor) }
         importsPackagesReplacementVisitor.replaceImports { `package` ->
             `package`
-                .replace(Regex("^${"$"}lib/registry/[^/]+"), config.aliases.components)
+                .replace(Regex("^${'$'}lib/registry/[^/]+"), config.aliases.components)
                 .replace("\$lib/utils", config.aliases.utils)
         }
     }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -2,6 +2,7 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.DependencyManager
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.ShellRunner
 import com.github.warningimhack3r.intellijshadcnplugin.backend.http.RequestSender
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
@@ -11,6 +12,7 @@ import com.github.warningimhack3r.intellijshadcnplugin.notifications.Notificatio
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -81,12 +83,15 @@ class SvelteSource(project: Project) : Source<SvelteConfig>(project, SvelteConfi
         } else extension
     }
 
-    override fun adaptFileToConfig(contents: String): String {
+    override fun adaptFileToConfig(file: PsiFile) {
         val config = getLocalConfig()
-        return contents.replace(
+        val newContents = file.text.replace(
             Regex("([\"'])[^\r\n/]+/registry/[^/]+"), "$1${cleanAlias(config.aliases.components)}"
         ).replace(
             "\$lib/utils", config.aliases.utils
         )
+        PsiHelper.writeAction(file, "Replacing imports") {
+            file.replace(PsiHelper.createPsiFile(project, file.fileType, newContents))
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -10,6 +10,7 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.remote.Co
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.ImportsPackagesReplacementVisitor
 import com.github.warningimhack3r.intellijshadcnplugin.notifications.NotificationManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
@@ -85,10 +86,12 @@ class SvelteSource(project: Project) : Source<SvelteConfig>(project, SvelteConfi
 
     override fun adaptFileToConfig(file: PsiFile) {
         val config = getLocalConfig()
-        file.accept(ImportsPackagesReplacementVisitor { import ->
-            import
+        val importsPackagesReplacementVisitor = ImportsPackagesReplacementVisitor(project)
+        runReadAction { file.accept(importsPackagesReplacementVisitor) }
+        importsPackagesReplacementVisitor.replaceImports { `package` ->
+            `package`
                 .replace(Regex("\\\$lib/registry/[^/]+"), config.aliases.components)
                 .replace("\$lib/utils", config.aliases.components)
-        })
+        }
     }
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
@@ -63,12 +63,12 @@ class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.seriali
     }
 
     override fun adaptFileExtensionToConfig(extension: String): String {
-        return if (!getLocalConfig().typescript) {
+        return if (getLocalConfig().typescript) extension else {
             extension.replace(
                 Regex("\\.ts$"),
                 ".js"
             )
-        } else extension
+        }
     }
 
     override fun adaptFileToConfig(file: PsiFile) {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/VueSource.kt
@@ -1,14 +1,16 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.VueConfig
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.remote.ComponentWithContents
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.VueClassReplacementVisitor
 import com.github.warningimhack3r.intellijshadcnplugin.notifications.NotificationManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.intellij.util.applyIf
+import com.intellij.psi.PsiFile
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -68,108 +70,59 @@ class VueSource(project: Project) : Source<VueConfig>(project, VueConfig.seriali
         } else extension
     }
 
-    override fun adaptFileToConfig(contents: String): String {
+    override fun adaptFileToConfig(file: PsiFile) {
         val config = getLocalConfig()
         // Note: this does not prevent additional imports other than "cn" from being replaced,
         // but I'm following what the original code does for parity
         // (https://github.com/radix-vue/shadcn-vue/blob/9d9a6f929ce0f281b4af36161af80ed2bbdc4a16/packages/cli/src/utils/transformers/transform-import.ts#L19-L29).
         val newContents = Regex(".*\\{.*[ ,\n\t]+cn[ ,].*}.*\"(@/lib/cn).*").replace(
-            contents.replace(
+            file.text.replace(
                 Regex("@/registry/[^/]+"), cleanAlias(config.aliases.components)
             )
         ) { result ->
             result.groupValues[0].replace(result.groupValues[1], cleanAlias(config.aliases.utils))
-        }.applyIf(!config.typescript) {
+        }
+
+        if (!config.typescript) {
             NotificationManager(project).sendNotification(
                 "TypeScript option for Vue",
                 "You have TypeScript disabled in your shadcn/ui config. This feature is not supported yet. Please install/update your components with the CLI for now.",
                 NotificationType.WARNING
             )
             // TODO: detype Vue file
-            this
         }
-        return if (!config.tailwind.cssVariables) {
-            /**
-             * Converts CSS variables to Tailwind utility classes.
-             * @param classes The classes to convert, an unquoted string of space-separated class names.
-             * @param lightColors The light colors map to use.
-             * @param darkColors The dark colors map to use.
-             * @return The converted classes.
-             */
-            fun variablesToUtilities(
-                classes: String,
-                lightColors: Map<String, String>,
-                darkColors: Map<String, String>
-            ): String {
-                // Note: this does not include `border` classes at the beginning or end of the string,
-                // but I'm once again following what the original code does for parity
-                // (https://github.com/radix-vue/shadcn-vue/blob/4214134e1834fdabcc5f0354e11593360f076e8d/packages/cli/src/utils/transformers/transform-css-vars.ts#L87-L89).
-                val newClasses = classes.replace(" border ", " border border-border ")
+        PsiHelper.writeAction(file, "Replacing imports") {
+            file.replace(PsiHelper.createPsiFile(project, file.fileType, newContents))
+        }
 
-                val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
+        if (!config.tailwind.cssVariables) {
+            val prefixesToReplace = listOf("bg-", "text-", "border-", "ring-offset-", "ring-")
 
-                /**
-                 * Replaces a class with CSS variables with Tailwind utility classes.
-                 * @param class The class to replace.
-                 * @return The replaced class.
-                 */
-                fun replaceClass(`class`: String): String {
-                    val prefix = prefixesToReplace.find { `class`.startsWith(it) } ?: return `class`
-                    val color = `class`.substringAfter(prefix)
-                    val lightColor = lightColors[color]
-                    val darkColor = darkColors[color]
-                    return if (lightColor != null && darkColor != null) {
-                        "$prefix$lightColor dark:$prefix$darkColor"
-                    } else `class`
+            val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
+                ?: throw Exception("Inline colors not found")
+            val lightColors = inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
+                lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
+            } ?: emptyMap()
+            val darkColors = inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
+                darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
+            } ?: emptyMap()
+
+            file.accept(VueClassReplacementVisitor visitor@{ `class` ->
+                val modifier = if (`class`.contains(":")) `class`.substringBeforeLast(":") + ":" else ""
+                val className = `class`.substringAfterLast(":")
+                if (className == "border") {
+                    return@visitor "${modifier}border ${modifier}border-border"
                 }
-
-                return newClasses
-                    .split(" ")
-                    .filterNot { it.isEmpty() }
-                    .joinToString(" ") {
-                        val className = it.trim().split(":")
-                        if (className.size == 1) {
-                            replaceClass(className[0])
-                        } else {
-                            "${className.dropLast(1).joinToString(":")}:${replaceClass(className.last())}"
-                        }
-                    }
-            }
-
-            fun handleClasses(classes: String): String {
-                val inlineColors = fetchColors().jsonObject["inlineColors"]?.jsonObject
-                    ?: throw Exception("Inline colors not found")
-                return variablesToUtilities(
-                    classes,
-                    inlineColors.jsonObject["light"]?.jsonObject?.let { lightColors ->
-                        lightColors.keys.associateWith { lightColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap(),
-                    inlineColors.jsonObject["dark"]?.jsonObject?.let { darkColors ->
-                        darkColors.keys.associateWith { darkColors[it]?.jsonPrimitive?.content ?: "" }
-                    } ?: emptyMap()
-                )
-            }
-
-            val notTemplateClasses =
-                Regex("[^:]class=(?:(?!>)[^\"'])*[\"']([^\"']*)[\"']").replace(newContents) { result ->
-                    result.groupValues[0].replace(
-                        result.groupValues[1],
-                        handleClasses(result.groupValues[1])
-                    )
-                }
-            // Double quoted templates
-            Regex(":class=(?:(?!>)[^\"])*\"([^\"]*)\"").replace(notTemplateClasses) { result ->
-                val group = result.groupValues[1]
-                result.groupValues[0].replace(
-                    group,
-                    handleClasses(group
-                        .replace("\n", " ")
-                        .split(", ")
-                        .map { it.trim() }
-                        .last { it.startsWith("'") || it.endsWith("'") })
-                )
-            }
-        } else newContents
+                val prefix = prefixesToReplace.find { className.startsWith(it) }
+                    ?: return@visitor "$modifier$className"
+                val color = className.substringAfter(prefix)
+                val lightColor = lightColors[color]
+                val darkColor = darkColors[color]
+                if (lightColor != null && darkColor != null) {
+                    "$modifier$prefix$lightColor dark:$modifier$prefix$darkColor"
+                } else "$modifier$className"
+            })
+        }
     }
 
     override fun getRegistryDependencies(component: ComponentWithContents): List<ComponentWithContents> {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
@@ -103,11 +103,12 @@ abstract class ClassReplacementVisitor(project: Project) : PsiRecursiveElementVi
     }
 
     private fun replaceClassName(element: PsiElement, newText: (String) -> String) {
-        val quote = when (element.text.first()) {
-            '\'', '`', '"' -> element.text.first().toString()
+        val text = runReadAction { element.text }
+        val quote = when (text.first()) {
+            '\'', '`', '"' -> text.first().toString()
             else -> ""
         }
-        val classes = element.text
+        val classes = text
             .split(" ")
             .filter { it.isNotEmpty() }
             .joinToString(" ") {

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
@@ -1,0 +1,46 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.intellij.lang.javascript.psi.impl.JSPsiElementFactory
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+
+abstract class ClassReplacementVisitor(
+    private val project: Project,
+    private val newClass: (String) -> String
+) : PsiRecursiveElementVisitor() {
+    abstract val attributePattern: PsiElementPattern.Capture<PsiElement>
+    abstract val attributeValuePattern: PsiElementPattern.Capture<PsiElement>
+
+    abstract fun classAttributeNameFromElement(element: PsiElement): String?
+
+    override fun visitElement(element: PsiElement) {
+        super.visitElement(element)
+
+        println("Visit: ${element.text} ($element/${element.javaClass})\n\t\tParent: ${element.parent} (${element.parent?.javaClass})")
+
+        if (attributeValuePattern.withParent(attributePattern).accepts(element)) {
+            println("Found valid value: ${element.text} ($element/${element.javaClass})")
+            val attributeName = classAttributeNameFromElement(element.parent) ?: return
+            if (attributeName != "className" && attributeName != "class") return
+            replaceClassName(element, newClass)
+        }
+    }
+
+    private fun replaceClassName(element: PsiElement, newText: (String) -> String) {
+        WriteCommandAction.runWriteCommandAction(project) {
+            val quote = when (element.text.first()) {
+                '\'' -> "'"
+                '`' -> "`"
+                else -> "\""
+            }
+            val classes = element.text.split(" ").filter(CharSequence::isNotEmpty).joinToString(" ") {
+                newText(it.replace(Regex(quote), ""))
+            }
+            val newElement = JSPsiElementFactory.createJSExpression("$quote$classes$quote", element)
+            element.replace(newElement)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
@@ -26,7 +26,10 @@ abstract class ClassReplacementVisitor(
     private val jsCallExpressionPattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(JSStubElementTypes.CALL_EXPRESSION)
     private val jsOrTsVariablePattern: PsiElementPattern.Capture<PsiElement> =
-        PlatformPatterns.psiElement(TypeScriptStubElementTypes.TYPESCRIPT_VARIABLE)
+        PlatformPatterns.psiElement().andOr(
+            PlatformPatterns.psiElement(TypeScriptStubElementTypes.TYPESCRIPT_VARIABLE),
+            PlatformPatterns.psiElement(JSStubElementTypes.VARIABLE)
+        )
 
     abstract fun classAttributeNameFromElement(element: PsiElement): String?
 
@@ -61,10 +64,12 @@ abstract class ClassReplacementVisitor(
             }
 
             jsCallExpressionPattern
-                .withChild(PlatformPatterns.psiElement().withText("tv"))
-                .withParent(jsOrTsVariablePattern)
-                .accepts(element) || jsCallExpressionPattern // there is probably a way to combine these two patterns
-                .withChild(PlatformPatterns.psiElement().withText("cva"))
+                .withChild(
+                    PlatformPatterns.psiElement().andOr(
+                        PlatformPatterns.psiElement().withText("tv"),
+                        PlatformPatterns.psiElement().withText("cva")
+                    )
+                )
                 .withParent(jsOrTsVariablePattern)
                 .accepts(element) -> {
                 // tailwind-variants & class-variance-authority

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ClassReplacementVisitor.kt
@@ -1,11 +1,14 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
 
+import com.intellij.lang.javascript.JSStubElementTypes
 import com.intellij.lang.javascript.psi.impl.JSPsiElementFactory
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.project.Project
+import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
+import com.intellij.psi.xml.XmlTokenType
 
 abstract class ClassReplacementVisitor(
     private val project: Project,
@@ -14,31 +17,65 @@ abstract class ClassReplacementVisitor(
     abstract val attributePattern: PsiElementPattern.Capture<PsiElement>
     abstract val attributeValuePattern: PsiElementPattern.Capture<PsiElement>
 
+    private val attributeValueTokenPattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+    private val jsLiteralExpressionPattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(JSStubElementTypes.LITERAL_EXPRESSION)
+    private val jsCallExpressionPattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(JSStubElementTypes.CALL_EXPRESSION)
+
     abstract fun classAttributeNameFromElement(element: PsiElement): String?
+
+    private fun printChildren(element: PsiElement, depth: Int = 0) {
+        element.children.forEach { child ->
+            println("${">".repeat(depth)}Child: ${child.text} ($child/${child.javaClass})")
+            printChildren(child, depth + 1)
+        }
+    }
 
     override fun visitElement(element: PsiElement) {
         super.visitElement(element)
 
-        println("Visit: ${element.text} ($element/${element.javaClass})\n\t\tParent: ${element.parent} (${element.parent?.javaClass})")
+        println("Visit: ${element.text} ($element/${element.javaClass})\n\t\tParent: ${element.parent?.text} (${element.parent}/${element.parent?.javaClass})")
 
-        if (attributeValuePattern.withParent(attributePattern).accepts(element)) {
-            println("Found valid value: ${element.text} ($element/${element.javaClass})")
-            val attributeName = classAttributeNameFromElement(element.parent) ?: return
-            if (attributeName != "className" && attributeName != "class") return
+        if (jsLiteralExpressionPattern
+                .withAncestor(2, jsCallExpressionPattern)
+                .withAncestor(5, attributeValuePattern)
+                .withAncestor(6, attributePattern)
+                .accepts(element)
+        ) {
+            // String literal inside a function call
+            println("Found valid expression call: '${element.text}' ($element/${element.javaClass})")
+            printChildren(element)
             replaceClassName(element, newClass)
+        } else if (attributeValueTokenPattern
+                .withParent(attributeValuePattern)
+                .withAncestor(2, attributePattern)
+                .accepts(element)
+        ) {
+            // Regular string attribute value
+            val attributeName = classAttributeNameFromElement(element.parent.parent) ?: return
+            if (attributeName != "className" && attributeName != "class") return
+            println("Found valid value: '${element.text}' ($element/${element.javaClass})")
+            printChildren(element)
+            replaceClassName(element.parent, newClass)
         }
     }
 
     private fun replaceClassName(element: PsiElement, newText: (String) -> String) {
         WriteCommandAction.runWriteCommandAction(project) {
             val quote = when (element.text.first()) {
-                '\'' -> "'"
-                '`' -> "`"
-                else -> "\""
+                '\'', '`', '"' -> element.text.first().toString()
+                else -> ""
             }
-            val classes = element.text.split(" ").filter(CharSequence::isNotEmpty).joinToString(" ") {
-                newText(it.replace(Regex(quote), ""))
-            }
+            val classes = element.text
+                .split(" ")
+                .filter { it.isNotEmpty() }
+                .joinToString(" ") {
+                    if (quote.isEmpty()) {
+                        newText(it)
+                    } else newText(it.replace(Regex(quote), ""))
+                }
             val newElement = JSPsiElementFactory.createJSExpression("$quote$classes$quote", element)
             element.replace(newElement)
         }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ImportsPackagesReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ImportsPackagesReplacementVisitor.kt
@@ -1,0 +1,40 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
+import com.intellij.lang.ecmascript6.ES6StubElementTypes
+import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.lang.javascript.psi.impl.JSPsiElementFactory
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+
+class ImportsPackagesReplacementVisitor(private val newImport: (String) -> String) : PsiRecursiveElementVisitor() {
+
+    override fun visitElement(element: PsiElement) {
+        super.visitElement(element)
+
+        if (PlatformPatterns.psiElement(JSTokenTypes.STRING_LITERAL)
+                .withParent(PlatformPatterns.psiElement(ES6StubElementTypes.FROM_CLAUSE))
+                .accepts(element)
+        ) {
+            replaceImport(element, newImport)
+        }
+    }
+
+    private fun replaceImport(element: PsiElement, newText: (String) -> String) {
+        val quote = when (element.text.first()) {
+            '\'', '`', '"' -> element.text.first().toString()
+            else -> ""
+        }
+        val newImport = element.text.let {
+            if (quote.isEmpty()) {
+                // Cannot happen, but just in case
+                newText(it)
+            } else newText(it.replace(Regex(quote), ""))
+        }
+        val newElement = JSPsiElementFactory.createJSExpression("$quote$newImport$quote", element)
+        PsiHelper.writeAction(element.containingFile) {
+            element.replace(newElement)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ImportsPackagesReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ImportsPackagesReplacementVisitor.kt
@@ -36,11 +36,12 @@ class ImportsPackagesReplacementVisitor(project: Project) : PsiRecursiveElementV
     }
 
     private fun replaceImport(element: PsiElement, newText: (String) -> String) {
-        val quote = when (element.text.first()) {
-            '\'', '`', '"' -> element.text.first().toString()
+        val text = runReadAction { element.text }
+        val quote = when (text.first()) {
+            '\'', '`', '"' -> text.first().toString()
             else -> ""
         }
-        val newImport = element.text.let {
+        val newImport = text.let {
             if (quote.isEmpty()) {
                 // Cannot happen, but just in case
                 newText(it)

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
@@ -2,12 +2,13 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacem
 
 import com.intellij.lang.javascript.JSStubElementTypes
 import com.intellij.lang.javascript.psi.e4x.impl.JSXmlAttributeImpl
+import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.xml.XmlElementType
 
-class JSXClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
+class JSXClassReplacementVisitor(project: Project) : ClassReplacementVisitor(project) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(JSStubElementTypes.XML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
@@ -1,0 +1,25 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.intellij.lang.javascript.JSStubElementTypes
+import com.intellij.lang.javascript.psi.e4x.impl.JSXmlAttributeImpl
+import com.intellij.openapi.project.Project
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.xml.XmlElementType
+
+class JSXClassReplacementVisitor(
+    project: Project,
+    newClass: (String) -> String
+) : ClassReplacementVisitor(project, newClass) {
+    override val attributePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(JSStubElementTypes.XML_ATTRIBUTE)
+    override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE_VALUE)
+
+    @Suppress("UnstableApiUsage")
+    override fun classAttributeNameFromElement(element: PsiElement): String? {
+        val attribute = element as? JSXmlAttributeImpl ?: return null
+        return attribute.name
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/JSXClassReplacementVisitor.kt
@@ -2,16 +2,12 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacem
 
 import com.intellij.lang.javascript.JSStubElementTypes
 import com.intellij.lang.javascript.psi.e4x.impl.JSXmlAttributeImpl
-import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.xml.XmlElementType
 
-class JSXClassReplacementVisitor(
-    project: Project,
-    newClass: (String) -> String
-) : ClassReplacementVisitor(project, newClass) {
+class JSXClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(JSStubElementTypes.XML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ReactDirectiveRemovalVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ReactDirectiveRemovalVisitor.kt
@@ -4,7 +4,7 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
 import com.intellij.lang.javascript.JSElementTypes
 import com.intellij.lang.javascript.JSStubElementTypes
 import com.intellij.lang.javascript.JSTokenTypes
-import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.*
@@ -49,13 +49,10 @@ class ReactDirectiveRemovalVisitor(
 
     @Suppress("UnstableApiUsage")
     fun removeMatchingElements() {
-        runWriteAction {
-            matchingElements.forEach { element ->
-                element.containingFile?.let {
-                    PsiHelper.writeAction(it) {
-                        element.dereference()?.delete()
-                    }
-                }
+        matchingElements.forEach { element ->
+            val psiElement = runReadAction { element.dereference() } ?: return
+            PsiHelper.writeAction(runReadAction { psiElement.containingFile }) {
+                psiElement.delete()
             }
         }
     }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ReactDirectiveRemovalVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/ReactDirectiveRemovalVisitor.kt
@@ -1,0 +1,62 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.PsiHelper
+import com.intellij.lang.javascript.JSElementTypes
+import com.intellij.lang.javascript.JSStubElementTypes
+import com.intellij.lang.javascript.JSTokenTypes
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.*
+
+class ReactDirectiveRemovalVisitor(
+    project: Project,
+    val directiveValue: (String) -> Boolean
+) : PsiRecursiveElementVisitor() {
+    private val matchingElements = mutableListOf<SmartPsiElementPointer<PsiElement>>()
+    private val smartPointerManager = SmartPointerManager.getInstance(project)
+
+    private val elementsToRemove = PlatformPatterns.psiElement().andOr(
+        PlatformPatterns.psiElement(JSTokenTypes.SEMICOLON),
+        PlatformPatterns.psiElement(CustomHighlighterTokenType.WHITESPACE)
+        // TODO: Find a way to remove newlines?
+    )
+
+    private var directiveFound = false
+    private var done = false
+
+    override fun visitElement(element: PsiElement) {
+        super.visitElement(element)
+
+        if (!done) {
+            val isDirectiveCandidate = PlatformPatterns.psiElement(JSElementTypes.EXPRESSION_STATEMENT)
+                .withChild(PlatformPatterns.psiElement(JSStubElementTypes.LITERAL_EXPRESSION))
+                .accepts(element)
+            val isJunk = elementsToRemove.accepts(element)
+
+            if (!directiveFound && isDirectiveCandidate && directiveValue(element.text.replace(Regex("['\";]"), ""))) {
+                matchingElements.add(smartPointerManager.createSmartPsiElementPointer(element))
+                directiveFound = true
+            } else if (directiveFound) {
+                if (isJunk) {
+                    matchingElements.add(smartPointerManager.createSmartPsiElementPointer(element))
+                } else {
+                    done = true
+                }
+            }
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    fun removeMatchingElements() {
+        runWriteAction {
+            matchingElements.forEach { element ->
+                element.containingFile?.let {
+                    PsiHelper.writeAction(it) {
+                        element.dereference()?.delete()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
@@ -1,6 +1,5 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
 
-import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
@@ -8,10 +7,7 @@ import com.intellij.psi.xml.XmlElementType
 import dev.blachut.svelte.lang.psi.SvelteHtmlAttribute
 import dev.blachut.svelte.lang.psi.SvelteHtmlElementTypes
 
-class SvelteClassReplacementVisitor(
-    project: Project,
-    newClass: (String) -> String
-) : ClassReplacementVisitor(project, newClass) {
+class SvelteClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(SvelteHtmlElementTypes.SVELTE_HTML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
@@ -1,5 +1,6 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
 
+import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
@@ -7,7 +8,7 @@ import com.intellij.psi.xml.XmlElementType
 import dev.blachut.svelte.lang.psi.SvelteHtmlAttribute
 import dev.blachut.svelte.lang.psi.SvelteHtmlElementTypes
 
-class SvelteClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
+class SvelteClassReplacementVisitor(project: Project) : ClassReplacementVisitor(project) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(SvelteHtmlElementTypes.SVELTE_HTML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/SvelteClassReplacementVisitor.kt
@@ -1,0 +1,24 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.intellij.openapi.project.Project
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.xml.XmlElementType
+import dev.blachut.svelte.lang.psi.SvelteHtmlAttribute
+import dev.blachut.svelte.lang.psi.SvelteHtmlElementTypes
+
+class SvelteClassReplacementVisitor(
+    project: Project,
+    newClass: (String) -> String
+) : ClassReplacementVisitor(project, newClass) {
+    override val attributePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(SvelteHtmlElementTypes.SVELTE_HTML_ATTRIBUTE)
+    override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE_VALUE)
+
+    override fun classAttributeNameFromElement(element: PsiElement): String? {
+        val attribute = element as? SvelteHtmlAttribute ?: return null
+        return attribute.name
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
@@ -1,16 +1,12 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
 
-import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.xml.XmlAttributeImpl
 import com.intellij.psi.xml.XmlElementType
 
-class VueClassReplacementVisitor(
-    project: Project,
-    newClass: (String) -> String
-) : ClassReplacementVisitor(project, newClass) {
+class VueClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
@@ -1,0 +1,23 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
+
+import com.intellij.openapi.project.Project
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.xml.XmlAttributeImpl
+import com.intellij.psi.xml.XmlElementType
+
+class VueClassReplacementVisitor(
+    project: Project,
+    newClass: (String) -> String
+) : ClassReplacementVisitor(project, newClass) {
+    override val attributePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE)
+    override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =
+        PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE_VALUE)
+
+    override fun classAttributeNameFromElement(element: PsiElement): String? {
+        val attribute = element as? XmlAttributeImpl ?: return null
+        return attribute.name
+    }
+}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/replacement/VueClassReplacementVisitor.kt
@@ -1,12 +1,13 @@
 package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement
 
+import com.intellij.openapi.project.Project
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.xml.XmlAttributeImpl
 import com.intellij.psi.xml.XmlElementType
 
-class VueClassReplacementVisitor(newClass: (String) -> String) : ClassReplacementVisitor(newClass) {
+class VueClassReplacementVisitor(project: Project) : ClassReplacementVisitor(project) {
     override val attributePattern: PsiElementPattern.Capture<PsiElement> =
         PlatformPatterns.psiElement(XmlElementType.XML_ATTRIBUTE)
     override val attributeValuePattern: PsiElementPattern.Capture<PsiElement> =

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPPanelPopulator.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPPanelPopulator.kt
@@ -2,7 +2,6 @@ package com.github.warningimhack3r.intellijshadcnplugin.ui
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.SourceScanner
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
@@ -22,11 +21,10 @@ class ISPPanelPopulator(private val project: Project) {
     fun populateToolWindowPanel(panel: JComponent) {
         log.info("Initializing tool window content")
         CoroutineScope(SupervisorJob() + Dispatchers.Default).async {
-            return@async Pair(runReadAction {
-                SourceScanner.findShadcnImplementation(project)
-            }, runReadAction {
-                FileManager(project).getVirtualFilesByName("package.json")
-            }.size)
+            return@async Pair(
+                SourceScanner.findShadcnImplementation(project),
+                FileManager(project).getVirtualFilesByName("package.json").size
+            )
         }.asCompletableFuture().thenApplyAsync { (source, packageJsonCount) ->
             log.info("Shadcn implementation detected: $source, package.json count: $packageJsonCount")
             panel.removeAll()

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
@@ -4,6 +4,7 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextField
+import com.intellij.util.SlowOperations
 import com.intellij.util.ui.JBUI
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.asCompletableFuture
@@ -69,7 +70,9 @@ class ISPWindowContents(private val source: Source<*>) {
                             } component for ${source.framework}",
                             listOf(
                                 LabeledAction("Add", CompletionAction.DISABLE_ROW) {
-                                    source.addComponent(component.name)
+                                    SlowOperations.allowSlowOperations<Throwable> {
+                                        source.addComponent(component.name)
+                                    }
                                 }
                             ),
                             installedComponents.contains(component.name)
@@ -93,8 +96,10 @@ class ISPWindowContents(private val source: Source<*>) {
                     JButton("Update all").apply {
                         addActionListener {
                             isEnabled = false
-                            installedComponents.forEach { component ->
-                                source.addComponent(component)
+                            SlowOperations.allowSlowOperations<Throwable> {
+                                installedComponents.forEach { component ->
+                                    source.addComponent(component)
+                                }
                             }
                             // TODO: Update the list's row actions
                             val par = parent
@@ -112,12 +117,16 @@ class ISPWindowContents(private val source: Source<*>) {
                             null,
                             listOfNotNull(
                                 LabeledAction("Update", CompletionAction.REMOVE_TRIGGER) {
-                                    source.addComponent(component)
+                                    SlowOperations.allowSlowOperations<Throwable> {
+                                        source.addComponent(component)
+                                    }
                                 }.takeIf {
                                     !source.isComponentUpToDate(component)
                                 },
                                 LabeledAction("Remove", CompletionAction.REMOVE_ROW) {
-                                    source.removeComponent(component)
+                                    SlowOperations.allowSlowOperations<Throwable> {
+                                        source.removeComponent(component)
+                                    }
                                 }
                             )
                         )

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
@@ -1,7 +1,6 @@
 package com.github.warningimhack3r.intellijshadcnplugin.ui
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.ui.components.JBScrollPane
@@ -52,7 +51,7 @@ class ISPWindowContents(private val source: Source<*>) {
         val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         var installedComponents = emptyList<String>()
         coroutineScope.launch {
-            installedComponents = runReadAction { source.getInstalledComponents() }
+            installedComponents = source.getInstalledComponents()
         }.invokeOnCompletion { throwable ->
             if (throwable != null && throwable !is CancellationException) {
                 return@invokeOnCompletion
@@ -60,7 +59,7 @@ class ISPWindowContents(private val source: Source<*>) {
             // Add a component panel
             add(createPanel("Add a component") {
                 coroutineScope.async {
-                    runReadAction { source.fetchAllComponents() }.map { component ->
+                    source.fetchAllComponents().map { component ->
                         Item(
                             component.name,
                             "${
@@ -90,9 +89,7 @@ class ISPWindowContents(private val source: Source<*>) {
             // Manage components panel
             add(createPanel("Manage components", coroutineScope.async {
                 val shouldDisplay =
-                    runReadAction {
-                        installedComponents.any { component -> !source.isComponentUpToDate(component) }
-                    }
+                    installedComponents.any { component -> !source.isComponentUpToDate(component) }
                 if (shouldDisplay) {
                     JButton("Update all").apply {
                         addActionListener {
@@ -118,7 +115,7 @@ class ISPWindowContents(private val source: Source<*>) {
                                 LabeledAction("Update", CompletionAction.REMOVE_TRIGGER) {
                                     runWriteAction { source.addComponent(component) }
                                 }.takeIf {
-                                    runReadAction { !source.isComponentUpToDate(component) }
+                                    !source.isComponentUpToDate(component)
                                 },
                                 LabeledAction("Remove", CompletionAction.REMOVE_ROW) {
                                     runWriteAction { source.removeComponent(component) }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ui/ISPWindowContents.kt
@@ -1,7 +1,6 @@
 package com.github.warningimhack3r.intellijshadcnplugin.ui
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextField
@@ -70,7 +69,7 @@ class ISPWindowContents(private val source: Source<*>) {
                             } component for ${source.framework}",
                             listOf(
                                 LabeledAction("Add", CompletionAction.DISABLE_ROW) {
-                                    runWriteAction { source.addComponent(component.name) }
+                                    source.addComponent(component.name)
                                 }
                             ),
                             installedComponents.contains(component.name)
@@ -95,7 +94,7 @@ class ISPWindowContents(private val source: Source<*>) {
                         addActionListener {
                             isEnabled = false
                             installedComponents.forEach { component ->
-                                runWriteAction { source.addComponent(component) }
+                                source.addComponent(component)
                             }
                             // TODO: Update the list's row actions
                             val par = parent
@@ -113,12 +112,12 @@ class ISPWindowContents(private val source: Source<*>) {
                             null,
                             listOfNotNull(
                                 LabeledAction("Update", CompletionAction.REMOVE_TRIGGER) {
-                                    runWriteAction { source.addComponent(component) }
+                                    source.addComponent(component)
                                 }.takeIf {
                                     !source.isComponentUpToDate(component)
                                 },
                                 LabeledAction("Remove", CompletionAction.REMOVE_ROW) {
-                                    runWriteAction { source.removeComponent(component) }
+                                    source.removeComponent(component)
                                 }
                             )
                         )

--- a/src/main/resources/META-INF/com.github.warningimhack3r.intellijshadcnplugin-withSvelte.xml
+++ b/src/main/resources/META-INF/com.github.warningimhack3r.intellijshadcnplugin-withSvelte.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/src/main/resources/META-INF/com.github.warningimhack3r.intellijshadcnplugin-withVue.xml
+++ b/src/main/resources/META-INF/com.github.warningimhack3r.intellijshadcnplugin-withVue.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,8 @@
     <vendor url="https://github.com/WarningImHack3r">WarningImHack3r</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>dev.blachut.svelte.lang</depends>
+    <depends>org.jetbrains.plugins.vue</depends>
 
     <actions>
         <action id="com.github.warningimhack3r.intellijshadcnplugin.errorsubmitter.ErrorThrowingAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,8 +5,12 @@
     <vendor url="https://github.com/WarningImHack3r">WarningImHack3r</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends>dev.blachut.svelte.lang</depends>
-    <depends>org.jetbrains.plugins.vue</depends>
+    <depends optional="true" config-file="com.github.warningimhack3r.intellijshadcnplugin-withSvelte.xml">
+        dev.blachut.svelte.lang
+    </depends>
+    <depends optional="true" config-file="com.github.warningimhack3r.intellijshadcnplugin-withVue.xml">
+        org.jetbrains.plugins.vue
+    </depends>
 
     <actions>
         <action id="com.github.warningimhack3r.intellijshadcnplugin.errorsubmitter.ErrorThrowingAction"

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -84,7 +84,7 @@ class ClassReplacementTests : BasePlatformTestCase() {
     }
 
     fun testFullSvelteVueTSClassReplacement() {
-        val (expected, actual) = beforeAndAfterContents("fullSvelteVueTS.ts")
+        val (expected, actual) = beforeAndAfterContents("fullSvelteVue.ts")
         assertEquals(expected, actual)
     }
 

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -88,6 +88,11 @@ class ClassReplacementTests : BasePlatformTestCase() {
         assertEquals(expected, actual)
     }
 
+    fun testFullSvelteVueJSClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullSvelteVue.js")
+        assertEquals(expected, actual)
+    }
+
     fun testFullSimpleVueComponentClassReplacement() {
         val (expected, actual) = beforeAndAfterContents("fullSimple.vue")
         assertEquals(expected, actual)

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -4,7 +4,6 @@ import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replaceme
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.JSXClassReplacementVisitor
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.SvelteClassReplacementVisitor
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.VueClassReplacementVisitor
-import com.intellij.openapi.project.Project
 import com.intellij.testFramework.TestDataPath
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import kotlin.reflect.KClass
@@ -17,14 +16,13 @@ class ClassReplacementTests : BasePlatformTestCase() {
 
     private fun createVisitor(
         visitorClass: KClass<out ClassReplacementVisitor>,
-        project: Project,
         newClass: (String) -> String
     ): ClassReplacementVisitor {
         val constructor = visitorClass.primaryConstructor
-        if (constructor != null && constructor.parameters.size == 2) {
-            return constructor.call(project, newClass)
+        if (constructor != null && constructor.parameters.size == 1) {
+            return constructor.call(newClass)
         } else {
-            throw IllegalArgumentException("Invalid visitor class. It should have a primary constructor with two parameters.")
+            throw IllegalArgumentException("Invalid visitor class. It should have a primary constructor with 1 parameter.")
         }
     }
 
@@ -36,7 +34,7 @@ class ClassReplacementTests : BasePlatformTestCase() {
             "vue" -> VueClassReplacementVisitor::class
             else -> throw IllegalArgumentException("Unsupported extension: $extension")
         }
-        val visitor = createVisitor(visitorClass, project) { "a-$it" }
+        val visitor = createVisitor(visitorClass) { "a-$it" }
         file.accept(visitor)
         return Pair(myFixture.configureByFile(fileName.let {
             it.substringBeforeLast('.') + "_after." + it.substringAfterLast('.')

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -31,7 +31,7 @@ class ClassReplacementTests : BasePlatformTestCase() {
     private fun beforeAndAfterContents(fileName: String): Pair<String, String> {
         val file = myFixture.configureByFile(fileName)
         val visitorClass = when (val extension = file.name.substringAfterLast('.')) {
-            "jsx", "tsx" -> JSXClassReplacementVisitor::class
+            "jsx", "tsx", "js", "ts" -> JSXClassReplacementVisitor::class
             "svelte" -> SvelteClassReplacementVisitor::class
             "vue" -> VueClassReplacementVisitor::class
             else -> throw IllegalArgumentException("Unsupported extension: $extension")
@@ -70,6 +70,41 @@ class ClassReplacementTests : BasePlatformTestCase() {
 
     fun testOtherAttributeReplacement() {
         val (expected, actual) = beforeAndAfterContents("simpleOtherAttribute.jsx")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullSimpleSvelteComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullSimple.svelte")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullComplexSvelteComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullComplex.svelte")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullSvelteVueTSClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullSvelteVueTS.ts")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullSimpleVueComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullSimple.vue")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullComplexVueComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullComplex.vue")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullSimpleJSXComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullSimple.tsx")
+        assertEquals(expected, actual)
+    }
+
+    fun testFullComplexJSXComponentClassReplacement() {
+        val (expected, actual) = beforeAndAfterContents("fullComplex.tsx")
         assertEquals(expected, actual)
     }
 }

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -14,13 +14,10 @@ class ClassReplacementTests : BasePlatformTestCase() {
 
     override fun getTestDataPath() = "src/test/testData/classReplacement"
 
-    private fun createVisitor(
-        visitorClass: KClass<out ClassReplacementVisitor>,
-        newClass: (String) -> String
-    ): ClassReplacementVisitor {
+    private fun createVisitor(visitorClass: KClass<out ClassReplacementVisitor>): ClassReplacementVisitor {
         val constructor = visitorClass.primaryConstructor
         if (constructor != null && constructor.parameters.size == 1) {
-            return constructor.call(newClass)
+            return constructor.call(project)
         } else {
             throw IllegalArgumentException("Invalid visitor class. It should have a primary constructor with 1 parameter.")
         }
@@ -34,8 +31,9 @@ class ClassReplacementTests : BasePlatformTestCase() {
             "vue" -> VueClassReplacementVisitor::class
             else -> throw IllegalArgumentException("Unsupported extension: $extension")
         }
-        val visitor = createVisitor(visitorClass) { "a-$it" }
+        val visitor = createVisitor(visitorClass)
         file.accept(visitor)
+        visitor.replaceClasses { "a-$it" }
         return Pair(myFixture.configureByFile(fileName.let {
             it.substringBeforeLast('.') + "_after." + it.substringAfterLast('.')
         }).text, file.text)

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ClassReplacementTests.kt
@@ -1,0 +1,169 @@
+package com.github.warningimhack3r.intellijshadcnplugin
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.ClassReplacementVisitor
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.JSXClassReplacementVisitor
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.SvelteClassReplacementVisitor
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.VueClassReplacementVisitor
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+class ClassReplacementTests : BasePlatformTestCase() {
+
+    private fun createVisitor(
+        visitorClass: KClass<out ClassReplacementVisitor>,
+        project: Project,
+        newClass: (String) -> String
+    ): ClassReplacementVisitor {
+        val constructor = visitorClass.primaryConstructor
+        if (constructor != null && constructor.parameters.size == 2) {
+            return constructor.call(project, newClass)
+        } else {
+            throw IllegalArgumentException("Invalid visitor class. It should have a primary constructor with two parameters.")
+        }
+    }
+
+    private fun processedFile(contents: String, extension: String): String {
+        val file = myFixture.configureByText("file.${extension.removePrefix(".")}", contents)
+        val visitorClass = when (extension) {
+            "jsx", "tsx" -> JSXClassReplacementVisitor::class
+            "svelte" -> SvelteClassReplacementVisitor::class
+            "vue" -> VueClassReplacementVisitor::class
+            else -> throw IllegalArgumentException("Unsupported extension: $extension")
+        }
+        val visitor = createVisitor(visitorClass, project) { "a-$it" }
+        file.accept(visitor)
+        return file.text
+    }
+
+    fun testBasicClassReplacement() {
+        val fileContent = """
+            const tag = <div className="foo">Hello, world!</div>;
+        """.trimIndent()
+
+        val expected = """
+            const tag = <div className="a-foo">Hello, world!</div>;
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "tsx"))
+    }
+
+    fun testSingleQuotesClassReplacement() {
+        val fileContent = """
+            const tag = <div className='foo'>Hello, world!</div>;
+        """.trimIndent()
+
+        val expected = """
+            const tag = <div className='a-foo'>Hello, world!</div>;
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "tsx"))
+    }
+
+    fun testSvelteClassReplacement() {
+        val fileContent = """
+            <script>
+                let name = "world";
+            </script>
+    
+            <h1 class="hello">Hello {name}!</h1>
+        """.trimIndent()
+
+        val expected = """
+            <script>
+                let name = "world";
+            </script>
+    
+            <h1 class="a-hello">Hello {name}!</h1>
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "svelte"))
+    }
+
+    fun testVueClassReplacement() {
+        val fileContent = """
+            <template>
+                <div id="app" class="foo">
+                    {{ message }}
+                </div>
+            </template>
+    
+            <script>
+                export default {
+                    data() {
+                        return {
+                            message: "Hello Vue!"
+                        }
+                    }
+                }
+            </script>
+        """.trimIndent()
+
+        val expected = """
+            <template>
+                <div id="app" class="a-foo">
+                    {{ message }}
+                </div>
+            </template>
+    
+            <script>
+                export default {
+                    data() {
+                        return {
+                            message: "Hello Vue!"
+                        }
+                    }
+                }
+            </script>
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "vue"))
+    }
+
+    fun testComprehensiveFileClassReplacement() {
+        val fileContent = """
+            <div class="foo">
+                <span class="bar">Hello, world!</span>
+                <p id="baz" class="qux">Goodbye, world!</p>
+            </div>
+        """.trimIndent()
+
+        val expected = """
+            <div class="a-foo">
+                <span class="a-bar">Hello, world!</span>
+                <p id="baz" class="a-qux">Goodbye, world!</p>
+            </div>
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "jsx"))
+    }
+
+    fun testOtherAttributeReplacement() {
+        val fileContent = """
+            <div id="foo">Hello, world!</div>
+        """.trimIndent()
+
+        val expected = """
+            <div id="foo">Hello, world!</div>
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "jsx"))
+    }
+
+    fun testMixAndMatchReplacement() {
+        val fileContent = """
+            <div class="foo" id="bar">
+                <span class="baz" id="qux">Hello, world!</span>
+            </div>
+        """.trimIndent()
+
+        val expected = """
+            <div class="a-foo" id="bar">
+                <span class="a-baz" id="qux">Hello, world!</span>
+            </div>
+        """.trimIndent()
+
+        assertEquals(expected, processedFile(fileContent, "tsx"))
+    }
+}

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/DummyTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/DummyTests.kt
@@ -1,9 +1,0 @@
-package com.github.warningimhack3r.intellijshadcnplugin
-
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
-
-class DummyTests : BasePlatformTestCase() {
-    fun testDummy() {
-        assertTrue(true)
-    }
-}

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ImportsReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ImportsReplacementTests.kt
@@ -11,7 +11,9 @@ class ImportsReplacementTests : BasePlatformTestCase() {
 
     private fun beforeAndAfterContents(fileName: String): Pair<String, String> {
         val file = myFixture.configureByFile(fileName)
-        file.accept(ImportsPackagesReplacementVisitor { "a-$it" })
+        val visitor = ImportsPackagesReplacementVisitor(project)
+        file.accept(visitor)
+        visitor.replaceImports { "a-$it" }
         return Pair(myFixture.configureByFile(fileName.let {
             it.substringBeforeLast('.') + "_after." + it.substringAfterLast('.')
         }).text, file.text)

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ImportsReplacementTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ImportsReplacementTests.kt
@@ -1,0 +1,59 @@
+package com.github.warningimhack3r.intellijshadcnplugin
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.ImportsPackagesReplacementVisitor
+import com.intellij.testFramework.TestDataPath
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+@TestDataPath("\$CONTENT_ROOT/src/test/testData")
+class ImportsReplacementTests : BasePlatformTestCase() {
+
+    override fun getTestDataPath() = "src/test/testData/importsReplacement"
+
+    private fun beforeAndAfterContents(fileName: String): Pair<String, String> {
+        val file = myFixture.configureByFile(fileName)
+        file.accept(ImportsPackagesReplacementVisitor { "a-$it" })
+        return Pair(myFixture.configureByFile(fileName.let {
+            it.substringBeforeLast('.') + "_after." + it.substringAfterLast('.')
+        }).text, file.text)
+    }
+
+    fun testJSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("imports.js")
+        assertEquals(expected, actual)
+    }
+
+    fun testTSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("imports.ts")
+        assertEquals(expected, actual)
+    }
+
+    fun testJSXImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("imports.jsx")
+        assertEquals(expected, actual)
+    }
+
+    fun testTSXImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("imports.tsx")
+        assertEquals(expected, actual)
+    }
+
+    fun testSvelteTSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("importsTS.svelte")
+        assertEquals(expected, actual)
+    }
+
+    fun testSvelteJSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("importsJS.svelte")
+        assertEquals(expected, actual)
+    }
+
+    fun testVueTSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("importsTS.vue")
+        assertEquals(expected, actual)
+    }
+
+    fun testVueJSImportsReplacement() {
+        val (expected, actual) = beforeAndAfterContents("importsJS.vue")
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ReactDirectiveRemovalTests.kt
+++ b/src/test/kotlin/com/github/warningimhack3r/intellijshadcnplugin/ReactDirectiveRemovalTests.kt
@@ -1,0 +1,31 @@
+package com.github.warningimhack3r.intellijshadcnplugin
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.ReactDirectiveRemovalVisitor
+import com.intellij.testFramework.TestDataPath
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+@TestDataPath("\$CONTENT_ROOT/src/test/testData")
+class ReactDirectiveRemovalTests : BasePlatformTestCase() {
+
+    override fun getTestDataPath() = "src/test/testData/reactDirectiveRemoval"
+
+    private fun beforeAndAfterContents(fileName: String): Pair<String, String> {
+        val file = myFixture.configureByFile(fileName)
+        val visitor = ReactDirectiveRemovalVisitor(project) { true }
+        file.accept(visitor)
+        visitor.removeMatchingElements()
+        return Pair(myFixture.configureByFile(fileName.let {
+            it.substringBeforeLast('.') + "_after." + it.substringAfterLast('.')
+        }).text, file.text)
+    }
+
+    fun testJSDirectiveRemoval() {
+        val (expected, actual) = beforeAndAfterContents("react.jsx")
+        assertEquals(expected, actual)
+    }
+
+    fun testTSDirectiveRemoval() {
+        val (expected, actual) = beforeAndAfterContents("react.tsx")
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/testData/classReplacement/basic.svelte
+++ b/src/test/testData/classReplacement/basic.svelte
@@ -1,0 +1,5 @@
+<script>
+    let name = "world";
+</script>
+
+<h1 class="hello">Hello {name}!</h1>

--- a/src/test/testData/classReplacement/basic.tsx
+++ b/src/test/testData/classReplacement/basic.tsx
@@ -1,0 +1,1 @@
+const tag = <div className="foo">Hello, world!</div>;

--- a/src/test/testData/classReplacement/basic.vue
+++ b/src/test/testData/classReplacement/basic.vue
@@ -1,0 +1,15 @@
+<template>
+  <div id="app" class="foo">
+    {{ message }}
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      message: "Hello Vue!"
+    }
+  }
+}
+</script>

--- a/src/test/testData/classReplacement/basic_after.svelte
+++ b/src/test/testData/classReplacement/basic_after.svelte
@@ -1,0 +1,5 @@
+<script>
+    let name = "world";
+</script>
+
+<h1 class="a-hello">Hello {name}!</h1>

--- a/src/test/testData/classReplacement/basic_after.tsx
+++ b/src/test/testData/classReplacement/basic_after.tsx
@@ -1,0 +1,1 @@
+const tag = <div className="a-foo">Hello, world!</div>;

--- a/src/test/testData/classReplacement/basic_after.vue
+++ b/src/test/testData/classReplacement/basic_after.vue
@@ -1,0 +1,15 @@
+<template>
+  <div id="app" class="a-foo">
+    {{ message }}
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      message: "Hello Vue!"
+    }
+  }
+}
+</script>

--- a/src/test/testData/classReplacement/fullComplex.svelte
+++ b/src/test/testData/classReplacement/fullComplex.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { Accordion as AccordionPrimitive } from "bits-ui";
+    import ChevronDown from "lucide-svelte/icons/chevron-down";
+    import { cn } from "$lib/utils.js";
+
+    type $$Props = AccordionPrimitive.TriggerProps;
+    type $$Events = AccordionPrimitive.TriggerEvents;
+
+    let className: $$Props["class"] = undefined;
+    export let level: AccordionPrimitive.HeaderProps["level"] = 3;
+    export { className as class };
+</script>
+
+<AccordionPrimitive.Header {level} class="flex">
+    <AccordionPrimitive.Trigger
+        class={cn(
+            "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+            className
+        )}
+        {...$$restProps}
+        on:click
+    >
+        <slot />
+        <ChevronDown class="h-4 w-4 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+</AccordionPrimitive.Header>

--- a/src/test/testData/classReplacement/fullComplex.tsx
+++ b/src/test/testData/classReplacement/fullComplex.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import {cn} from "@/lib/utils"
+import {buttonVariants} from "@/registry/default/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Overlay
+        className={cn(
+            "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            className
+        )}
+        {...props}
+        ref={ref}
+    />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({className, ...props}, ref) => (
+    <AlertDialogPortal>
+        <AlertDialogOverlay/>
+        <AlertDialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+                className
+            )}
+            {...props}
+        />
+    </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+                               className,
+                               ...props
+                           }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "flex flex-col space-y-2 text-center sm:text-left",
+            className
+        )}
+        {...props}
+    />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+                               className,
+                               ...props
+                           }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+            className
+        )}
+        {...props}
+    />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Title
+        ref={ref}
+        className={cn("text-lg font-semibold", className)}
+        {...props}
+    />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Description
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+    />
+))
+AlertDialogDescription.displayName =
+    AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Action>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Action
+        ref={ref}
+        className={cn(buttonVariants(), className)}
+        {...props}
+    />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Cancel
+        ref={ref}
+        className={cn(
+            buttonVariants({variant: "outline"}),
+            "mt-2 sm:mt-0",
+            className
+        )}
+        {...props}
+    />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+    AlertDialog,
+    AlertDialogPortal,
+    AlertDialogOverlay,
+    AlertDialogTrigger,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogFooter,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogAction,
+    AlertDialogCancel,
+}

--- a/src/test/testData/classReplacement/fullComplex.tsx
+++ b/src/test/testData/classReplacement/fullComplex.tsx
@@ -3,8 +3,8 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import {cn} from "@/lib/utils"
-import {buttonVariants} from "@/registry/default/ui/button"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/registry/default/ui/button"
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/src/test/testData/classReplacement/fullComplex.vue
+++ b/src/test/testData/classReplacement/fullComplex.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import {computed, type HTMLAttributes} from 'vue'
+import {
+  AlertDialogContent,
+  type AlertDialogContentEmits,
+  type AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+} from 'radix-vue'
+import {cn} from '@/lib/utils'
+
+const props = defineProps<AlertDialogContentProps & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<AlertDialogContentEmits>()
+
+const delegatedProps = computed(() => {
+  const {class: _, ...delegated} = props
+
+  return delegated
+})
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <AlertDialogPortal>
+    <AlertDialogOverlay
+        class="fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+    />
+    <AlertDialogContent
+        v-bind="forwarded"
+        :class="
+          cn(
+            'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+            props.class,
+          )
+        "
+    >
+      <slot/>
+    </AlertDialogContent>
+  </AlertDialogPortal>
+</template>

--- a/src/test/testData/classReplacement/fullComplex.vue
+++ b/src/test/testData/classReplacement/fullComplex.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed, type HTMLAttributes} from 'vue'
+import { computed, type HTMLAttributes } from 'vue'
 import {
   AlertDialogContent,
   type AlertDialogContentEmits,
@@ -8,7 +8,7 @@ import {
   AlertDialogPortal,
   useForwardPropsEmits,
 } from 'radix-vue'
-import {cn} from '@/lib/utils'
+import { cn } from '@/lib/utils'
 
 const props = defineProps<AlertDialogContentProps & { class?: HTMLAttributes['class'] }>()
 const emits = defineEmits<AlertDialogContentEmits>()

--- a/src/test/testData/classReplacement/fullComplex_after.svelte
+++ b/src/test/testData/classReplacement/fullComplex_after.svelte
@@ -11,7 +11,7 @@
     export { className as class };
 </script>
 
-<AccordionPrimitive.Header {level} class="flex">
+<AccordionPrimitive.Header {level} class="a-flex">
     <AccordionPrimitive.Trigger
         class={cn(
             "a-flex a-flex-1 a-items-center a-justify-between a-py-4 a-font-medium a-transition-all a-hover:underline a-[&[data-state=open]>svg]:rotate-180",
@@ -21,6 +21,6 @@
         on:click
     >
         <slot />
-        <ChevronDown class="a-h-4 a-w-4 a-transition-transform a-duration-200" />
+        <ChevronDown class="a-h-4 a-w-4 a-transition-transform a-duration-200"/>
     </AccordionPrimitive.Trigger>
 </AccordionPrimitive.Header>

--- a/src/test/testData/classReplacement/fullComplex_after.svelte
+++ b/src/test/testData/classReplacement/fullComplex_after.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { Accordion as AccordionPrimitive } from "bits-ui";
+    import ChevronDown from "lucide-svelte/icons/chevron-down";
+    import { cn } from "$lib/utils.js";
+
+    type $$Props = AccordionPrimitive.TriggerProps;
+    type $$Events = AccordionPrimitive.TriggerEvents;
+
+    let className: $$Props["class"] = undefined;
+    export let level: AccordionPrimitive.HeaderProps["level"] = 3;
+    export { className as class };
+</script>
+
+<AccordionPrimitive.Header {level} class="flex">
+    <AccordionPrimitive.Trigger
+        class={cn(
+            "a-flex a-flex-1 a-items-center a-justify-between a-py-4 a-font-medium a-transition-all a-hover:underline a-[&[data-state=open]>svg]:rotate-180",
+            className
+        )}
+        {...$$restProps}
+        on:click
+    >
+        <slot />
+        <ChevronDown class="a-h-4 a-w-4 a-transition-transform a-duration-200" />
+    </AccordionPrimitive.Trigger>
+</AccordionPrimitive.Header>

--- a/src/test/testData/classReplacement/fullComplex_after.tsx
+++ b/src/test/testData/classReplacement/fullComplex_after.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import {cn} from "@/lib/utils"
+import {buttonVariants} from "@/registry/default/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Overlay
+        className={cn(
+            "a-fixed a-inset-0 a-z-50 a-bg-black/80 a-data-[state=open]:animate-in a-data-[state=closed]:animate-out a-data-[state=closed]:fade-out-0 a-data-[state=open]:fade-in-0",
+            className
+        )}
+        {...props}
+        ref={ref}
+    />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({className, ...props}, ref) => (
+    <AlertDialogPortal>
+        <AlertDialogOverlay/>
+        <AlertDialogPrimitive.Content
+            ref={ref}
+            className={cn(
+                "a-fixed a-left-[50%] a-top-[50%] a-z-50 a-grid a-w-full a-max-w-lg a-translate-x-[-50%] a-translate-y-[-50%] a-gap-4 a-border a-bg-background a-p-6 a-shadow-lg a-duration-200 a-data-[state=open]:animate-in a-data-[state=closed]:animate-out a-data-[state=closed]:fade-out-0 a-data-[state=open]:fade-in-0 a-data-[state=closed]:zoom-out-95 a-data-[state=open]:zoom-in-95 a-data-[state=closed]:slide-out-to-left-1/2 a-data-[state=closed]:slide-out-to-top-[48%] a-data-[state=open]:slide-in-from-left-1/2 a-data-[state=open]:slide-in-from-top-[48%] a-sm:rounded-lg",
+                className
+            )}
+            {...props}
+        />
+    </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+                               className,
+                               ...props
+                           }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "a-flex a-flex-col a-space-y-2 a-text-center a-sm:text-left",
+            className
+        )}
+        {...props}
+    />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+                               className,
+                               ...props
+                           }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn(
+            "a-flex a-flex-col-reverse a-sm:flex-row a-sm:justify-end a-sm:space-x-2",
+            className
+        )}
+        {...props}
+    />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Title
+        ref={ref}
+        className={cn("a-text-lg a-font-semibold", className)}
+        {...props}
+    />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Description
+        ref={ref}
+        className={cn("a-text-sm a-text-muted-foreground", className)}
+        {...props}
+    />
+))
+AlertDialogDescription.displayName =
+    AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Action>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Action
+        ref={ref}
+        className={cn(buttonVariants(), className)}
+        {...props}
+    />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+    React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+    React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({className, ...props}, ref) => (
+    <AlertDialogPrimitive.Cancel
+        ref={ref}
+        className={cn(
+            buttonVariants({variant: "outline"}),
+            "a-mt-2 a-sm:mt-0",
+            className
+        )}
+        {...props}
+    />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+    AlertDialog,
+    AlertDialogPortal,
+    AlertDialogOverlay,
+    AlertDialogTrigger,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogFooter,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogAction,
+    AlertDialogCancel,
+}

--- a/src/test/testData/classReplacement/fullComplex_after.tsx
+++ b/src/test/testData/classReplacement/fullComplex_after.tsx
@@ -3,8 +3,8 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import {cn} from "@/lib/utils"
-import {buttonVariants} from "@/registry/default/ui/button"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/registry/default/ui/button"
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/src/test/testData/classReplacement/fullComplex_after.vue
+++ b/src/test/testData/classReplacement/fullComplex_after.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import {computed, type HTMLAttributes} from 'vue'
+import {
+  AlertDialogContent,
+  type AlertDialogContentEmits,
+  type AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+} from 'radix-vue'
+import {cn} from '@/lib/utils'
+
+const props = defineProps<AlertDialogContentProps & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<AlertDialogContentEmits>()
+
+const delegatedProps = computed(() => {
+  const {class: _, ...delegated} = props
+
+  return delegated
+})
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <AlertDialogPortal>
+    <AlertDialogOverlay
+        class="a-fixed a-inset-0 a-z-50 a-bg-black/80 a-data-[state=open]:animate-in a-data-[state=closed]:animate-out a-data-[state=closed]:fade-out-0 a-data-[state=open]:fade-in-0"
+    />
+    <AlertDialogContent
+        v-bind="forwarded"
+        :class="
+          cn(
+            'a-fixed a-left-1/2 a-top-1/2 a-z-50 a-grid a-w-full a-max-w-lg a--translate-x-1/2 a--translate-y-1/2 a-gap-4 a-border a-bg-background a-p-6 a-shadow-lg a-duration-200 a-data-[state=open]:animate-in a-data-[state=closed]:animate-out a-data-[state=closed]:fade-out-0 a-data-[state=open]:fade-in-0 a-data-[state=closed]:zoom-out-95 a-data-[state=open]:zoom-in-95 a-data-[state=closed]:slide-out-to-left-1/2 a-data-[state=closed]:slide-out-to-top-[48%] a-data-[state=open]:slide-in-from-left-1/2 a-data-[state=open]:slide-in-from-top-[48%] a-sm:rounded-lg',
+            props.class,
+          )
+        "
+    >
+      <slot/>
+    </AlertDialogContent>
+  </AlertDialogPortal>
+</template>

--- a/src/test/testData/classReplacement/fullComplex_after.vue
+++ b/src/test/testData/classReplacement/fullComplex_after.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed, type HTMLAttributes} from 'vue'
+import { computed, type HTMLAttributes } from 'vue'
 import {
   AlertDialogContent,
   type AlertDialogContentEmits,
@@ -8,7 +8,7 @@ import {
   AlertDialogPortal,
   useForwardPropsEmits,
 } from 'radix-vue'
-import {cn} from '@/lib/utils'
+import { cn } from '@/lib/utils'
 
 const props = defineProps<AlertDialogContentProps & { class?: HTMLAttributes['class'] }>()
 const emits = defineEmits<AlertDialogContentEmits>()

--- a/src/test/testData/classReplacement/fullSimple.svelte
+++ b/src/test/testData/classReplacement/fullSimple.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { Avatar as AvatarPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    type $$Props = AvatarPrimitive.Props;
+
+    let className: $$Props["class"] = undefined;
+    export let delayMs: $$Props["delayMs"] = undefined;
+    export { className as class };
+</script>
+
+<AvatarPrimitive.Root
+    {delayMs}
+    class={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
+    {...$$restProps}
+>
+    <slot />
+</AvatarPrimitive.Root>

--- a/src/test/testData/classReplacement/fullSimple.tsx
+++ b/src/test/testData/classReplacement/fullSimple.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import {Slot} from "@radix-ui/react-slot"
+import {cva, type VariantProps} from "class-variance-authority"
+
+import {cn} from "@/lib/utils"
+
+const buttonVariants = cva(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    {
+        variants: {
+            variant: {
+                default: "bg-primary text-primary-foreground hover:bg-primary/90",
+                destructive:
+                    "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+                outline:
+                    "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+                secondary:
+                    "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                ghost: "hover:bg-accent hover:text-accent-foreground",
+                link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+                default: "h-10 px-4 py-2",
+                sm: "h-9 rounded-md px-3",
+                lg: "h-11 rounded-md px-8",
+                icon: "h-10 w-10",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    }
+)
+
+export interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+        VariantProps<typeof buttonVariants> {
+    asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({className, variant, size, asChild = false, ...props}, ref) => {
+        const Comp = asChild ? Slot : "button"
+        return (
+            <Comp
+                className={cn(buttonVariants({variant, size, className}))}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
+Button.displayName = "Button"
+
+export {Button, buttonVariants}

--- a/src/test/testData/classReplacement/fullSimple.tsx
+++ b/src/test/testData/classReplacement/fullSimple.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
     "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/src/test/testData/classReplacement/fullSimple.vue
+++ b/src/test/testData/classReplacement/fullSimple.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type {HTMLAttributes} from 'vue'
+import {cn} from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <h5 :class="cn('mb-1 font-medium leading-none tracking-tight', props.class)">
+    <slot/>
+  </h5>
+</template>

--- a/src/test/testData/classReplacement/fullSimple.vue
+++ b/src/test/testData/classReplacement/fullSimple.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type {HTMLAttributes} from 'vue'
-import {cn} from '@/lib/utils'
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
 
 const props = defineProps<{
   class?: HTMLAttributes['class']

--- a/src/test/testData/classReplacement/fullSimple_after.svelte
+++ b/src/test/testData/classReplacement/fullSimple_after.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { Avatar as AvatarPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    type $$Props = AvatarPrimitive.Props;
+
+    let className: $$Props["class"] = undefined;
+    export let delayMs: $$Props["delayMs"] = undefined;
+    export { className as class };
+</script>
+
+<AvatarPrimitive.Root
+    {delayMs}
+    class={cn("a-relative a-flex a-h-10 a-w-10 a-shrink-0 a-overflow-hidden a-rounded-full", className)}
+    {...$$restProps}
+>
+    <slot />
+</AvatarPrimitive.Root>

--- a/src/test/testData/classReplacement/fullSimple_after.tsx
+++ b/src/test/testData/classReplacement/fullSimple_after.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import {Slot} from "@radix-ui/react-slot"
+import {cva, type VariantProps} from "class-variance-authority"
+
+import {cn} from "@/lib/utils"
+
+const buttonVariants = cva(
+    "a-inline-flex a-items-center a-justify-center a-whitespace-nowrap a-rounded-md a-text-sm a-font-medium a-ring-offset-background a-transition-colors a-focus-visible:outline-none a-focus-visible:ring-2 a-focus-visible:ring-ring a-focus-visible:ring-offset-2 a-disabled:pointer-events-none a-disabled:opacity-50",
+    {
+        variants: {
+            variant: {
+                default: "a-bg-primary a-text-primary-foreground a-hover:bg-primary/90",
+                destructive:
+                    "a-bg-destructive a-text-destructive-foreground a-hover:bg-destructive/90",
+                outline:
+                    "a-border a-border-input a-bg-background a-hover:bg-accent a-hover:text-accent-foreground",
+                secondary:
+                    "a-bg-secondary a-text-secondary-foreground a-hover:bg-secondary/80",
+                ghost: "a-hover:bg-accent a-hover:text-accent-foreground",
+                link: "a-text-primary a-underline-offset-4 a-hover:underline",
+            },
+            size: {
+                default: "a-h-10 a-px-4 a-py-2",
+                sm: "a-h-9 a-rounded-md a-px-3",
+                lg: "a-h-11 a-rounded-md a-px-8",
+                icon: "a-h-10 a-w-10",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    }
+)
+
+export interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+        VariantProps<typeof buttonVariants> {
+    asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({className, variant, size, asChild = false, ...props}, ref) => {
+        const Comp = asChild ? Slot : "button"
+        return (
+            <Comp
+                className={cn(buttonVariants({variant, size, className}))}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
+Button.displayName = "Button"
+
+export {Button, buttonVariants}

--- a/src/test/testData/classReplacement/fullSimple_after.tsx
+++ b/src/test/testData/classReplacement/fullSimple_after.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import {cn} from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
     "a-inline-flex a-items-center a-justify-center a-whitespace-nowrap a-rounded-md a-text-sm a-font-medium a-ring-offset-background a-transition-colors a-focus-visible:outline-none a-focus-visible:ring-2 a-focus-visible:ring-ring a-focus-visible:ring-offset-2 a-disabled:pointer-events-none a-disabled:opacity-50",

--- a/src/test/testData/classReplacement/fullSimple_after.vue
+++ b/src/test/testData/classReplacement/fullSimple_after.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type {HTMLAttributes} from 'vue'
-import {cn} from '@/lib/utils'
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
 
 const props = defineProps<{
   class?: HTMLAttributes['class']

--- a/src/test/testData/classReplacement/fullSimple_after.vue
+++ b/src/test/testData/classReplacement/fullSimple_after.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type {HTMLAttributes} from 'vue'
+import {cn} from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <h5 :class="cn('a-mb-1 a-font-medium a-leading-none a-tracking-tight', props.class)">
+    <slot/>
+  </h5>
+</template>

--- a/src/test/testData/classReplacement/fullSvelteVue.js
+++ b/src/test/testData/classReplacement/fullSvelteVue.js
@@ -1,4 +1,4 @@
-import {tv} from "tailwind-variants";
+import { tv } from "tailwind-variants";
 import Root from "./button.svelte";
 
 const buttonVariants = tv({

--- a/src/test/testData/classReplacement/fullSvelteVue.js
+++ b/src/test/testData/classReplacement/fullSvelteVue.js
@@ -1,0 +1,34 @@
+import {tv} from "tailwind-variants";
+import Root from "./button.svelte";
+
+const buttonVariants = tv({
+    base: "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    variants: {
+        variant: {
+            default: "bg-primary text-primary-foreground hover:bg-primary/90",
+            destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            outline:
+                "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+            secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+            ghost: "hover:bg-accent hover:text-accent-foreground",
+            link: "text-primary underline-offset-4 hover:underline",
+        },
+        size: {
+            default: "h-10 px-4 py-2",
+            sm: "h-9 rounded-md px-3",
+            lg: "h-11 rounded-md px-8",
+            icon: "h-10 w-10",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+        size: "default",
+    },
+});
+
+export {
+    Root,
+    //
+    Root as Button,
+    buttonVariants,
+};

--- a/src/test/testData/classReplacement/fullSvelteVue.ts
+++ b/src/test/testData/classReplacement/fullSvelteVue.ts
@@ -1,0 +1,49 @@
+import {tv, type VariantProps} from "tailwind-variants";
+import type {Button as ButtonPrimitive} from "bits-ui";
+import Root from "./button.svelte";
+
+const buttonVariants = tv({
+    base: "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    variants: {
+        variant: {
+            default: "bg-primary text-primary-foreground hover:bg-primary/90",
+            destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            outline:
+                "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+            secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+            ghost: "hover:bg-accent hover:text-accent-foreground",
+            link: "text-primary underline-offset-4 hover:underline",
+        },
+        size: {
+            default: "h-10 px-4 py-2",
+            sm: "h-9 rounded-md px-3",
+            lg: "h-11 rounded-md px-8",
+            icon: "h-10 w-10",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+        size: "default",
+    },
+});
+
+type Variant = VariantProps<typeof buttonVariants>["variant"];
+type Size = VariantProps<typeof buttonVariants>["size"];
+
+type Props = ButtonPrimitive.Props & {
+    variant?: Variant;
+    size?: Size;
+};
+
+type Events = ButtonPrimitive.Events;
+
+export {
+    Root,
+    type Props,
+    type Events,
+    //
+    Root as Button,
+    type Props as ButtonProps,
+    type Events as ButtonEvents,
+    buttonVariants,
+};

--- a/src/test/testData/classReplacement/fullSvelteVue.ts
+++ b/src/test/testData/classReplacement/fullSvelteVue.ts
@@ -1,5 +1,5 @@
-import {tv, type VariantProps} from "tailwind-variants";
-import type {Button as ButtonPrimitive} from "bits-ui";
+import { tv, type VariantProps } from "tailwind-variants";
+import type { Button as ButtonPrimitive } from "bits-ui";
 import Root from "./button.svelte";
 
 const buttonVariants = tv({

--- a/src/test/testData/classReplacement/fullSvelteVue_after.js
+++ b/src/test/testData/classReplacement/fullSvelteVue_after.js
@@ -1,4 +1,4 @@
-import {tv} from "tailwind-variants";
+import { tv } from "tailwind-variants";
 import Root from "./button.svelte";
 
 const buttonVariants = tv({

--- a/src/test/testData/classReplacement/fullSvelteVue_after.js
+++ b/src/test/testData/classReplacement/fullSvelteVue_after.js
@@ -1,0 +1,34 @@
+import {tv} from "tailwind-variants";
+import Root from "./button.svelte";
+
+const buttonVariants = tv({
+    base: "a-inline-flex a-items-center a-justify-center a-whitespace-nowrap a-rounded-md a-text-sm a-font-medium a-ring-offset-background a-transition-colors a-focus-visible:outline-none a-focus-visible:ring-2 a-focus-visible:ring-ring a-focus-visible:ring-offset-2 a-disabled:pointer-events-none a-disabled:opacity-50",
+    variants: {
+        variant: {
+            default: "a-bg-primary a-text-primary-foreground a-hover:bg-primary/90",
+            destructive: "a-bg-destructive a-text-destructive-foreground a-hover:bg-destructive/90",
+            outline:
+                "a-border a-border-input a-bg-background a-hover:bg-accent a-hover:text-accent-foreground",
+            secondary: "a-bg-secondary a-text-secondary-foreground a-hover:bg-secondary/80",
+            ghost: "a-hover:bg-accent a-hover:text-accent-foreground",
+            link: "a-text-primary a-underline-offset-4 a-hover:underline",
+        },
+        size: {
+            default: "a-h-10 a-px-4 a-py-2",
+            sm: "a-h-9 a-rounded-md a-px-3",
+            lg: "a-h-11 a-rounded-md a-px-8",
+            icon: "a-h-10 a-w-10",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+        size: "default",
+    },
+});
+
+export {
+    Root,
+    //
+    Root as Button,
+    buttonVariants,
+};

--- a/src/test/testData/classReplacement/fullSvelteVue_after.ts
+++ b/src/test/testData/classReplacement/fullSvelteVue_after.ts
@@ -1,5 +1,5 @@
-import {tv, type VariantProps} from "tailwind-variants";
-import type {Button as ButtonPrimitive} from "bits-ui";
+import { tv, type VariantProps } from "tailwind-variants";
+import type { Button as ButtonPrimitive } from "bits-ui";
 import Root from "./button.svelte";
 
 const buttonVariants = tv({

--- a/src/test/testData/classReplacement/fullSvelteVue_after.ts
+++ b/src/test/testData/classReplacement/fullSvelteVue_after.ts
@@ -1,0 +1,49 @@
+import {tv, type VariantProps} from "tailwind-variants";
+import type {Button as ButtonPrimitive} from "bits-ui";
+import Root from "./button.svelte";
+
+const buttonVariants = tv({
+    base: "a-inline-flex a-items-center a-justify-center a-whitespace-nowrap a-rounded-md a-text-sm a-font-medium a-ring-offset-background a-transition-colors a-focus-visible:outline-none a-focus-visible:ring-2 a-focus-visible:ring-ring a-focus-visible:ring-offset-2 a-disabled:pointer-events-none a-disabled:opacity-50",
+    variants: {
+        variant: {
+            default: "a-bg-primary a-text-primary-foreground a-hover:bg-primary/90",
+            destructive: "a-bg-destructive a-text-destructive-foreground a-hover:bg-destructive/90",
+            outline:
+                "a-border a-border-input a-bg-background a-hover:bg-accent a-hover:text-accent-foreground",
+            secondary: "a-bg-secondary a-text-secondary-foreground a-hover:bg-secondary/80",
+            ghost: "a-hover:bg-accent a-hover:text-accent-foreground",
+            link: "a-text-primary a-underline-offset-4 a-hover:underline",
+        },
+        size: {
+            default: "a-h-10 a-px-4 a-py-2",
+            sm: "a-h-9 a-rounded-md a-px-3",
+            lg: "a-h-11 a-rounded-md a-px-8",
+            icon: "a-h-10 a-w-10",
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+        size: "default",
+    },
+});
+
+type Variant = VariantProps<typeof buttonVariants>["variant"];
+type Size = VariantProps<typeof buttonVariants>["size"];
+
+type Props = ButtonPrimitive.Props & {
+    variant?: Variant;
+    size?: Size;
+};
+
+type Events = ButtonPrimitive.Events;
+
+export {
+    Root,
+    type Props,
+    type Events,
+    //
+    Root as Button,
+    type Props as ButtonProps,
+    type Events as ButtonEvents,
+    buttonVariants,
+};

--- a/src/test/testData/classReplacement/nestedAndOtherAttributes.jsx
+++ b/src/test/testData/classReplacement/nestedAndOtherAttributes.jsx
@@ -1,0 +1,4 @@
+const tag = <div className="foo">
+    <span className="bar">Hello, world!</span>
+    <p id="baz" className="qux">Goodbye, world!</p>
+</div>

--- a/src/test/testData/classReplacement/nestedAndOtherAttributes_after.jsx
+++ b/src/test/testData/classReplacement/nestedAndOtherAttributes_after.jsx
@@ -1,0 +1,4 @@
+const tag = <div className="a-foo">
+    <span className="a-bar">Hello, world!</span>
+    <p id="baz" className="a-qux">Goodbye, world!</p>
+</div>

--- a/src/test/testData/classReplacement/simpleOtherAttribute.jsx
+++ b/src/test/testData/classReplacement/simpleOtherAttribute.jsx
@@ -1,0 +1,1 @@
+<div id="foo">Hello, world!</div>;

--- a/src/test/testData/classReplacement/simpleOtherAttribute_after.jsx
+++ b/src/test/testData/classReplacement/simpleOtherAttribute_after.jsx
@@ -1,0 +1,1 @@
+<div id="foo">Hello, world!</div>;

--- a/src/test/testData/classReplacement/singleQuotes.tsx
+++ b/src/test/testData/classReplacement/singleQuotes.tsx
@@ -1,0 +1,1 @@
+const tag = <div className='foo'>Hello, world!</div>;

--- a/src/test/testData/classReplacement/singleQuotes_after.tsx
+++ b/src/test/testData/classReplacement/singleQuotes_after.tsx
@@ -1,0 +1,1 @@
+const tag = <div className='a-foo'>Hello, world!</div>;

--- a/src/test/testData/importsReplacement/imports.js
+++ b/src/test/testData/importsReplacement/imports.js
@@ -1,0 +1,12 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import {cn} from "@/lib/utils"
+import {buttonVariants} from "@/registry/default/ui/button"
+
+export {
+    React,
+    AlertDialogPrimitive,
+    cn,
+    buttonVariants
+}

--- a/src/test/testData/importsReplacement/imports.js
+++ b/src/test/testData/importsReplacement/imports.js
@@ -1,12 +1,5 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import {cn} from "@/lib/utils"
-import {buttonVariants} from "@/registry/default/ui/button"
-
-export {
-    React,
-    AlertDialogPrimitive,
-    cn,
-    buttonVariants
-}
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/registry/default/ui/button"

--- a/src/test/testData/importsReplacement/imports.jsx
+++ b/src/test/testData/importsReplacement/imports.jsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import {cn} from "@/lib/utils"
+import {buttonVariants} from "@/registry/default/ui/button"
+
+export {
+    React,
+    AlertDialogPrimitive,
+    cn,
+    buttonVariants
+}

--- a/src/test/testData/importsReplacement/imports.jsx
+++ b/src/test/testData/importsReplacement/imports.jsx
@@ -1,12 +1,5 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import {cn} from "@/lib/utils"
-import {buttonVariants} from "@/registry/default/ui/button"
-
-export {
-    React,
-    AlertDialogPrimitive,
-    cn,
-    buttonVariants
-}
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/registry/default/ui/button"

--- a/src/test/testData/importsReplacement/imports.ts
+++ b/src/test/testData/importsReplacement/imports.ts
@@ -1,0 +1,13 @@
+import * as React from "react"
+import {Slot} from "@radix-ui/react-slot"
+import {cva, type VariantProps} from "class-variance-authority"
+
+import {cn} from "@/lib/utils"
+
+export {
+    React,
+    Slot,
+    cn,
+    cva,
+    VariantProps
+}

--- a/src/test/testData/importsReplacement/imports.ts
+++ b/src/test/testData/importsReplacement/imports.ts
@@ -1,13 +1,5 @@
 import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import {cn} from "@/lib/utils"
-
-export {
-    React,
-    Slot,
-    cn,
-    cva,
-    VariantProps
-}
+import { cn } from "@/lib/utils"

--- a/src/test/testData/importsReplacement/imports.tsx
+++ b/src/test/testData/importsReplacement/imports.tsx
@@ -1,0 +1,13 @@
+import * as React from "react"
+import {Slot} from "@radix-ui/react-slot"
+import {cva, type VariantProps} from "class-variance-authority"
+
+import {cn} from "@/lib/utils"
+
+export {
+    React,
+    Slot,
+    cn,
+    cva,
+    VariantProps
+}

--- a/src/test/testData/importsReplacement/imports.tsx
+++ b/src/test/testData/importsReplacement/imports.tsx
@@ -1,13 +1,5 @@
 import * as React from "react"
-import {Slot} from "@radix-ui/react-slot"
-import {cva, type VariantProps} from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import {cn} from "@/lib/utils"
-
-export {
-    React,
-    Slot,
-    cn,
-    cva,
-    VariantProps
-}
+import { cn } from "@/lib/utils"

--- a/src/test/testData/importsReplacement/importsJS.svelte
+++ b/src/test/testData/importsReplacement/importsJS.svelte
@@ -1,0 +1,5 @@
+<script>
+    import { Accordion as AccordionPrimitive } from "bits-ui";
+    import ChevronDown from "lucide-svelte/icons/chevron-down";
+    import { cn } from "$lib/utils.js";
+</script>

--- a/src/test/testData/importsReplacement/importsJS.vue
+++ b/src/test/testData/importsReplacement/importsJS.vue
@@ -1,0 +1,14 @@
+<script setup>
+import {computed} from 'vue'
+import {AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits,} from 'radix-vue'
+import {cn} from '@/lib/utils'
+
+export {
+  computed,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+  cn
+}
+</script>

--- a/src/test/testData/importsReplacement/importsJS.vue
+++ b/src/test/testData/importsReplacement/importsJS.vue
@@ -1,14 +1,5 @@
 <script setup>
-import {computed} from 'vue'
-import {AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits,} from 'radix-vue'
-import {cn} from '@/lib/utils'
-
-export {
-  computed,
-  AlertDialogContent,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  useForwardPropsEmits,
-  cn
-}
+import { computed } from 'vue'
+import { AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits } from 'radix-vue'
+import { cn } from '@/lib/utils'
 </script>

--- a/src/test/testData/importsReplacement/importsJS_after.svelte
+++ b/src/test/testData/importsReplacement/importsJS_after.svelte
@@ -1,0 +1,5 @@
+<script>
+    import { Accordion as AccordionPrimitive } from "a-bits-ui";
+    import ChevronDown from "a-lucide-svelte/icons/chevron-down";
+    import { cn } from "a-$lib/utils.js";
+</script>

--- a/src/test/testData/importsReplacement/importsJS_after.vue
+++ b/src/test/testData/importsReplacement/importsJS_after.vue
@@ -1,0 +1,14 @@
+<script setup>
+import {computed} from 'a-vue'
+import {AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits,} from 'a-radix-vue'
+import {cn} from 'a-@/lib/utils'
+
+export {
+  computed,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+  cn
+}
+</script>

--- a/src/test/testData/importsReplacement/importsJS_after.vue
+++ b/src/test/testData/importsReplacement/importsJS_after.vue
@@ -1,14 +1,5 @@
 <script setup>
-import {computed} from 'a-vue'
-import {AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits,} from 'a-radix-vue'
-import {cn} from 'a-@/lib/utils'
-
-export {
-  computed,
-  AlertDialogContent,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  useForwardPropsEmits,
-  cn
-}
+import { computed } from 'a-vue'
+import { AlertDialogContent, AlertDialogOverlay, AlertDialogPortal, useForwardPropsEmits } from 'a-radix-vue'
+import { cn } from 'a-@/lib/utils'
 </script>

--- a/src/test/testData/importsReplacement/importsTS.svelte
+++ b/src/test/testData/importsReplacement/importsTS.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import { Accordion as AccordionPrimitive, type AccordionProps } from "bits-ui";
+    import ChevronDown from "lucide-svelte/icons/chevron-down";
+    import { cn } from "$lib/utils.js";
+</script>

--- a/src/test/testData/importsReplacement/importsTS.vue
+++ b/src/test/testData/importsReplacement/importsTS.vue
@@ -1,24 +1,12 @@
 <script setup lang="ts">
-import {computed, type HTMLAttributes} from 'vue'
+import { computed, type HTMLAttributes } from 'vue'
 import {
   AlertDialogContent,
   type AlertDialogContentEmits,
   type AlertDialogContentProps,
   AlertDialogOverlay,
   AlertDialogPortal,
-  useForwardPropsEmits,
+  useForwardPropsEmits
 } from 'radix-vue'
-import {cn} from '@/lib/utils'
-
-export {
-  computed,
-  HTMLAttributes,
-  AlertDialogContent,
-  AlertDialogContentEmits,
-  AlertDialogContentProps,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  useForwardPropsEmits,
-  cn
-}
+import { cn } from '@/lib/utils'
 </script>

--- a/src/test/testData/importsReplacement/importsTS.vue
+++ b/src/test/testData/importsReplacement/importsTS.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import {computed, type HTMLAttributes} from 'vue'
+import {
+  AlertDialogContent,
+  type AlertDialogContentEmits,
+  type AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+} from 'radix-vue'
+import {cn} from '@/lib/utils'
+
+export {
+  computed,
+  HTMLAttributes,
+  AlertDialogContent,
+  AlertDialogContentEmits,
+  AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+  cn
+}
+</script>

--- a/src/test/testData/importsReplacement/importsTS_after.svelte
+++ b/src/test/testData/importsReplacement/importsTS_after.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import { Accordion as AccordionPrimitive, type AccordionProps } from "a-bits-ui";
+    import ChevronDown from "a-lucide-svelte/icons/chevron-down";
+    import { cn } from "a-$lib/utils.js";
+</script>

--- a/src/test/testData/importsReplacement/importsTS_after.vue
+++ b/src/test/testData/importsReplacement/importsTS_after.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import {computed, type HTMLAttributes} from 'a-vue'
+import {
+  AlertDialogContent,
+  type AlertDialogContentEmits,
+  type AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+} from 'a-radix-vue'
+import {cn} from 'a-@/lib/utils'
+
+export {
+  computed,
+  HTMLAttributes,
+  AlertDialogContent,
+  AlertDialogContentEmits,
+  AlertDialogContentProps,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  useForwardPropsEmits,
+  cn
+}
+</script>

--- a/src/test/testData/importsReplacement/importsTS_after.vue
+++ b/src/test/testData/importsReplacement/importsTS_after.vue
@@ -1,24 +1,12 @@
 <script setup lang="ts">
-import {computed, type HTMLAttributes} from 'a-vue'
+import { computed, type HTMLAttributes } from 'a-vue'
 import {
   AlertDialogContent,
   type AlertDialogContentEmits,
   type AlertDialogContentProps,
   AlertDialogOverlay,
   AlertDialogPortal,
-  useForwardPropsEmits,
+  useForwardPropsEmits
 } from 'a-radix-vue'
-import {cn} from 'a-@/lib/utils'
-
-export {
-  computed,
-  HTMLAttributes,
-  AlertDialogContent,
-  AlertDialogContentEmits,
-  AlertDialogContentProps,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  useForwardPropsEmits,
-  cn
-}
+import { cn } from 'a-@/lib/utils'
 </script>

--- a/src/test/testData/importsReplacement/imports_after.js
+++ b/src/test/testData/importsReplacement/imports_after.js
@@ -1,0 +1,12 @@
+import * as React from "a-react"
+import * as AlertDialogPrimitive from "a-@radix-ui/react-alert-dialog"
+
+import {cn} from "a-@/lib/utils"
+import {buttonVariants} from "a-@/registry/default/ui/button"
+
+export {
+    React,
+    AlertDialogPrimitive,
+    cn,
+    buttonVariants
+}

--- a/src/test/testData/importsReplacement/imports_after.js
+++ b/src/test/testData/importsReplacement/imports_after.js
@@ -1,12 +1,5 @@
 import * as React from "a-react"
 import * as AlertDialogPrimitive from "a-@radix-ui/react-alert-dialog"
 
-import {cn} from "a-@/lib/utils"
-import {buttonVariants} from "a-@/registry/default/ui/button"
-
-export {
-    React,
-    AlertDialogPrimitive,
-    cn,
-    buttonVariants
-}
+import { cn } from "a-@/lib/utils"
+import { buttonVariants } from "a-@/registry/default/ui/button"

--- a/src/test/testData/importsReplacement/imports_after.jsx
+++ b/src/test/testData/importsReplacement/imports_after.jsx
@@ -1,0 +1,12 @@
+import * as React from "a-react"
+import * as AlertDialogPrimitive from "a-@radix-ui/react-alert-dialog"
+
+import {cn} from "a-@/lib/utils"
+import {buttonVariants} from "a-@/registry/default/ui/button"
+
+export {
+    React,
+    AlertDialogPrimitive,
+    cn,
+    buttonVariants
+}

--- a/src/test/testData/importsReplacement/imports_after.jsx
+++ b/src/test/testData/importsReplacement/imports_after.jsx
@@ -1,12 +1,5 @@
 import * as React from "a-react"
 import * as AlertDialogPrimitive from "a-@radix-ui/react-alert-dialog"
 
-import {cn} from "a-@/lib/utils"
-import {buttonVariants} from "a-@/registry/default/ui/button"
-
-export {
-    React,
-    AlertDialogPrimitive,
-    cn,
-    buttonVariants
-}
+import { cn } from "a-@/lib/utils"
+import { buttonVariants } from "a-@/registry/default/ui/button"

--- a/src/test/testData/importsReplacement/imports_after.ts
+++ b/src/test/testData/importsReplacement/imports_after.ts
@@ -1,0 +1,13 @@
+import * as React from "a-react"
+import {Slot} from "a-@radix-ui/react-slot"
+import {cva, type VariantProps} from "a-class-variance-authority"
+
+import {cn} from "a-@/lib/utils"
+
+export {
+    React,
+    Slot,
+    cn,
+    cva,
+    VariantProps
+}

--- a/src/test/testData/importsReplacement/imports_after.ts
+++ b/src/test/testData/importsReplacement/imports_after.ts
@@ -1,13 +1,5 @@
 import * as React from "a-react"
-import {Slot} from "a-@radix-ui/react-slot"
-import {cva, type VariantProps} from "a-class-variance-authority"
+import { Slot } from "a-@radix-ui/react-slot"
+import { cva, type VariantProps } from "a-class-variance-authority"
 
-import {cn} from "a-@/lib/utils"
-
-export {
-    React,
-    Slot,
-    cn,
-    cva,
-    VariantProps
-}
+import { cn } from "a-@/lib/utils"

--- a/src/test/testData/importsReplacement/imports_after.tsx
+++ b/src/test/testData/importsReplacement/imports_after.tsx
@@ -1,0 +1,13 @@
+import * as React from "a-react"
+import {Slot} from "a-@radix-ui/react-slot"
+import {cva, type VariantProps} from "a-class-variance-authority"
+
+import {cn} from "a-@/lib/utils"
+
+export {
+    React,
+    Slot,
+    cn,
+    cva,
+    VariantProps
+}

--- a/src/test/testData/importsReplacement/imports_after.tsx
+++ b/src/test/testData/importsReplacement/imports_after.tsx
@@ -1,13 +1,5 @@
 import * as React from "a-react"
-import {Slot} from "a-@radix-ui/react-slot"
-import {cva, type VariantProps} from "a-class-variance-authority"
+import { Slot } from "a-@radix-ui/react-slot"
+import { cva, type VariantProps } from "a-class-variance-authority"
 
-import {cn} from "a-@/lib/utils"
-
-export {
-    React,
-    Slot,
-    cn,
-    cva,
-    VariantProps
-}
+import { cn } from "a-@/lib/utils"

--- a/src/test/testData/reactDirectiveRemoval/react.jsx
+++ b/src/test/testData/reactDirectiveRemoval/react.jsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ReactDirectiveRemoval() {
+    const [state, _] = useState(0);
+    return <div>{
+        state === 0 ? <div>0</div> : <div>1</div>
+    }</div>;
+}

--- a/src/test/testData/reactDirectiveRemoval/react.tsx
+++ b/src/test/testData/reactDirectiveRemoval/react.tsx
@@ -1,0 +1,10 @@
+'use server'
+
+import { useState } from "react";
+
+export default function ReactDirectiveRemoval() {
+    const [state, _] = useState(0);
+    return <div>{
+        state === 0 ? <div>0</div> : <div>1</div>
+    }</div>;
+}

--- a/src/test/testData/reactDirectiveRemoval/react_after.jsx
+++ b/src/test/testData/reactDirectiveRemoval/react_after.jsx
@@ -1,0 +1,10 @@
+
+
+import { useState } from "react";
+
+export default function ReactDirectiveRemoval() {
+    const [state, _] = useState(0);
+    return <div>{
+        state === 0 ? <div>0</div> : <div>1</div>
+    }</div>;
+}

--- a/src/test/testData/reactDirectiveRemoval/react_after.tsx
+++ b/src/test/testData/reactDirectiveRemoval/react_after.tsx
@@ -1,0 +1,10 @@
+
+
+import { useState } from "react";
+
+export default function ReactDirectiveRemoval() {
+    const [state, _] = useState(0);
+    return <div>{
+        state === 0 ? <div>0</div> : <div>1</div>
+    }</div>;
+}


### PR DESCRIPTION
Replace the regex-based Tailwind classes replacement mechanism with an AST-based one. It will help better support various cases not working with the current implementation, as well as reduce the code verbosity.

The AST parsing requires the built-in `JavaScript` module, which is only available on WebStorm and IntelliJ IDEA Ultimate. **Other IDEs are thus no longer supported**.

Also, the [Svelte](https://plugins.jetbrains.com/plugin/12375-svelte) and [Vue](https://plugins.jetbrains.com/plugin/9442-vue-js) extensions (JSX support is built-in/sufficient with the `JavaScript` module), mandatory to be able to parse their associated files, are also **now dependencies of this plugin**.  
~~Vue is already a built-in plugin for IU & WS, however Svelte will have (unless I find a workaround) to be installed with this plugin.~~ However, both plugins are optional to install.

A similar engine is also brought to the imports replacement part, as well as for React's `"use X"` directives. Frameworks configurations have also been updated for comprehensive implementations.

## TODO list

- [x] Make parsing of all supported file types working
- [x] Add more complex tests and support cases for robustness and real-world situations support
- [x] Implement file visitors into the real sources
- [x] Check for regressions and working implementations
- [x] Try to make Svelte plugin dependency optional (Vue is already built-in for both IU and WS)