### PR TITLE
Overhaul Solid implementations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Consequently, the plugin now depends
       on [Svelte](https://plugins.jetbrains.com/plugin/12375-svelte) & [Vue](https://plugins.jetbrains.com/plugin/9442-vue-js)
       extensions and only works on WebStorm or IntelliJ IDEA Ultimate
+- Overhaul support for Solid as both implementations diverged from shadcn/ui
 - Improve crash reporter to include more relevant information
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - Add support for Vue `typescript` option (transpiling TypeScript to JavaScript as well as in `*.vue` files)
   - See https://github.com/radix-vue/shadcn-vue/issues/378
+- Add support for React/Solid (UI) `tsx` option (transpiling TypeScript to JavaScript)
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Manage your shadcn/ui components in your project. Supports Svelte, React, Vue, a
 
 This plugin will help you manage your shadcn/ui components through a simple tool window. Add, remove, update them with a
 single click.  
-**This plugin will only work with an existing `components.json` file. Manually copied components will not be detected
+**This plugin will only work with an existing `components.json` (or `ui.config.json` for Solid UI) file. Manually copied components will not be detected
 otherwise.**
 
 ## Features

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/SourceScanner.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/SourceScanner.kt
@@ -16,7 +16,8 @@ object SourceScanner {
     val log = logger<SourceScanner>()
 
     fun findShadcnImplementation(project: Project): Source<*>? {
-        return FileManager(project).getFileContentsAtPath("components.json")?.let { componentsJson ->
+        val fileManager = FileManager(project)
+        return fileManager.getFileContentsAtPath("components.json")?.let { componentsJson ->
             val contents = Json.parseToJsonElement(componentsJson).jsonObject
             val schema = contents["\$schema"]?.jsonPrimitive?.content ?: ""
             when {
@@ -26,6 +27,8 @@ object SourceScanner {
                 schema.contains("shadcn-solid") || schema.contains("solid-ui.com") -> SolidSource(project)
                 else -> null
             }
+        } ?: fileManager.getFileContentsAtPath("ui.config.json")?.let {
+            SolidSource(project, "ui.config.json")
         }.also {
             if (it == null) log.warn("No shadcn implementation found")
             else log.info("Found shadcn implementation: ${it.javaClass.name}")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/SourceScanner.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/SourceScanner.kt
@@ -2,10 +2,7 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend
 
 import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
 import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
-import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl.ReactSource
-import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl.SolidSource
-import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl.SvelteSource
-import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl.VueSource
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl.*
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import kotlinx.serialization.json.Json
@@ -28,7 +25,7 @@ object SourceScanner {
                 else -> null
             }
         } ?: fileManager.getFileContentsAtPath("ui.config.json")?.let {
-            SolidSource(project, "ui.config.json")
+            SolidUISource(project)
         }.also {
             if (it == null) log.warn("No shadcn implementation found")
             else log.info("Found shadcn implementation: ${it.javaClass.name}")

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/FileManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/FileManager.kt
@@ -57,12 +57,12 @@ class FileManager(private val project: Project) {
             // because it works fine during local development.
             runReadAction {
                 FilenameIndex.getVirtualFilesByName(
-                    "components.json",
+                    "package.json",
                     GlobalSearchScope.projectScope(project)
                 )
             }.firstOrNull().also {
                 if (it == null) {
-                    log.warn("components.json not found with the workaround")
+                    log.warn("package.json not found with the workaround")
                 }
             }?.parent?.children?.filter {
                 it.name.contains(name)

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/UnparseableConfigException.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/UnparseableConfigException.kt
@@ -6,13 +6,13 @@ import com.intellij.openapi.project.Project
 
 class UnparseableConfigException(
     project: Project,
-    message: String? = null,
+    configName: String,
     cause: Throwable? = null
-) : Exception(message, cause) {
+) : Exception("Unable to parse $configName", cause) {
     init {
         NotificationManager(project).sendNotification(
             "Unparseable configuration file",
-            "Your <code>components.json</code> file could not be parsed.<br />Please check that it is a valid JSON and that it contains the correct fields.",
+            "Your <code>${configName}</code> file could not be parsed.<br />Please check that it is a valid JSON and that it contains the correct fields.",
             NotificationType.ERROR
         )
     }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/Config.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/Config.kt
@@ -14,14 +14,9 @@ sealed class Config {
     abstract val `$schema`: String
 
     /**
-     * The library's style used.
-     */
-    abstract val style: String
-
-    /**
      * The Tailwind configuration.
      */
-    abstract val tailwind: Tailwind
+    abstract val tailwind: Tailwind?
 
     /**
      * The aliases for the components and utils directories.
@@ -42,26 +37,11 @@ sealed class Config {
          * The relative path of the Tailwind CSS file.
          */
         abstract val css: String
-
-        /**
-         * The library's base color.
-         */
-        abstract val baseColor: String
     }
 
     /**
      * The aliases for the components and utils directories.
      */
     @Serializable
-    sealed class Aliases {
-        /**
-         * The alias for the components' directory.
-         */
-        abstract val components: String
-
-        /**
-         * The alias for the utils directory.
-         */
-        abstract val utils: String
-    }
+    sealed class Aliases
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidConfig.kt
@@ -2,18 +2,66 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config
 
 import kotlinx.serialization.Serializable
 
+/**
+ * A shadcn-svelte locally installed components.json file.
+ * @param `$schema` The schema URL for the file.
+ * @param tailwind The Tailwind configuration.
+ * @param uno The UnoCSS configuration.
+ * @param aliases The aliases for the components and utils directories.
+ */
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
 class SolidConfig(
     override val `$schema`: String = "",
-    override val style: String,
-    override val tailwind: VueConfig.Tailwind,
+    override val tailwind: Tailwind? = null,
+    val uno: Uno? = null,
     override val aliases: Aliases
 ) : Config() {
 
+    /**
+     * The Tailwind configuration.
+     * @param config The relative path to the Tailwind config file.
+     * @param css The relative path of the Tailwind CSS file.
+     * @param baseColor The library's base color.
+     * @param cssVariables Whether to use CSS variables or utility classes.
+     * @param prefix The prefix to use for utility classes.
+     */
+    @Serializable
+    class Tailwind(
+        override val config: String,
+        override val css: String,
+        val baseColor: String,
+        val cssVariables: Boolean = true,
+        val prefix: String = ""
+    ) : Config.Tailwind()
+
+    /**
+     * The UnoCSS configuration.
+     * @param config The relative path to the UnoCSS config file.
+     * @param css The relative path of the UnoCSS file.
+     * @param baseColor The library's base color.
+     * @param cssVariables Whether to use CSS variables or utility classes.
+     * @param prefix The prefix to use for utility classes.
+     */
+    @Serializable
+    class Uno(
+        override val config: String,
+        override val css: String,
+        val baseColor: String,
+        val cssVariables: Boolean = true,
+        val prefix: String = ""
+    ) : Config.Tailwind()
+
+    /**
+     * The aliases for the components and utils directories.
+     * @param components The alias for the components' directory.
+     * @param utils The alias for the utils directory.
+     * @param ui The alias for the UI directory.
+     */
     @Serializable
     class Aliases(
-        override val components: String,
-        override val utils: String
+        val components: String,
+        val utils: String,
+        val ui: String? = null
     ) : Config.Aliases()
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidUIConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SolidUIConfig.kt
@@ -5,19 +5,17 @@ import kotlinx.serialization.Serializable
 /**
  * A shadcn-svelte locally installed components.json file.
  * @param `$schema` The schema URL for the file.
- * @param style The library's style used.
- * @param rsc Whether to support React Server Components.
  * @param tsx Whether to use TypeScript over JavaScript.
+ * @param componentDir The components' directory.
  * @param tailwind The Tailwind configuration.
  * @param aliases The aliases for the components and utils directories.
  */
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
-class ReactConfig(
-    override val `$schema`: String = "https://ui.shadcn.com/schema.json",
-    val style: String,
-    val rsc: Boolean = false,
-    val tsx: Boolean = true,
+class SolidUIConfig(
+    override val `$schema`: String = "",
+    val tsx: Boolean,
+    val componentDir: String,
     override val tailwind: Tailwind,
     override val aliases: Aliases
 ) : Config() {
@@ -26,29 +24,19 @@ class ReactConfig(
      * The Tailwind configuration.
      * @param config The relative path to the Tailwind config file.
      * @param css The relative path of the Tailwind CSS file.
-     * @param baseColor The library's base color.
-     * @param cssVariables Whether to use CSS variables or utility classes.
-     * @param prefix The prefix to use for utility classes.
      */
     @Serializable
     class Tailwind(
         override val config: String,
-        override val css: String,
-        val baseColor: String,
-        val cssVariables: Boolean = true,
-        val prefix: String = ""
+        override val css: String
     ) : Config.Tailwind()
 
     /**
      * The aliases for the components and utils directories.
-     * @param components The alias for the components' directory.
-     * @param utils The alias for the utils directory.
-     * @param ui The alias for UI components.
+     * @param path The import alias for the `src` directory.
      */
     @Serializable
     class Aliases(
-        val components: String,
-        val utils: String,
-        val ui: String? = null
+        val path: String,
     ) : Config.Aliases()
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SvelteConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/SvelteConfig.kt
@@ -2,26 +2,45 @@ package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config
 
 import kotlinx.serialization.Serializable
 
+/**
+ * A shadcn-svelte locally installed components.json file.
+ * @param `$schema` The schema URL for the file.
+ * @param style The library's style used.
+ * @param tailwind The Tailwind configuration.
+ * @param aliases The aliases for the components and utils directories.
+ * @param typescript Whether to use TypeScript over JavaScript.
+ */
 @Suppress("PROVIDED_RUNTIME_TOO_LOW", "kotlin:S117")
 @Serializable
 class SvelteConfig(
     override val `$schema`: String = "https://shadcn-svelte.com/schema.json",
-    override val style: String,
+    val style: String,
     override val tailwind: Tailwind,
     override val aliases: Aliases,
     val typescript: Boolean = true
 ) : Config() {
 
+    /**
+     * The Tailwind configuration.
+     * @param config The relative path to the Tailwind config file.
+     * @param css The relative path of the Tailwind CSS file.
+     * @param baseColor The library's base color.
+     */
     @Serializable
     class Tailwind(
         override val config: String,
         override val css: String,
-        override val baseColor: String
+        val baseColor: String
     ) : Config.Tailwind()
 
+    /**
+     * The aliases for the components and utils directories.
+     * @param components The alias for the components' directory.
+     * @param utils The alias for the utils directory.
+     */
     @Serializable
     class Aliases(
-        override val components: String,
-        override val utils: String
+        val components: String,
+        val utils: String
     ) : Config.Aliases()
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/VueConfig.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/config/VueConfig.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 class VueConfig(
     override val `$schema`: String = "https://shadcn-vue.com/schema.json",
-    override val style: String,
+    val style: String,
     val typescript: Boolean = true,
     val tsConfigPath: String = "./tsconfig.json",
     override val tailwind: Tailwind,
@@ -30,12 +30,13 @@ class VueConfig(
      * @param css The relative path of the Tailwind CSS file.
      * @param baseColor The library's base color.
      * @param cssVariables Whether to use CSS variables instead of Tailwind utility classes.
+     * @param prefix The prefix to use for utility classes.
      */
     @Serializable
     open class Tailwind(
         override val config: String,
         override val css: String,
-        override val baseColor: String,
+        val baseColor: String,
         val cssVariables: Boolean = true,
         val prefix: String = ""
     ) : Config.Tailwind()
@@ -59,10 +60,16 @@ class VueConfig(
         ASTRO
     }
 
+    /**
+     * The aliases for the components and utils directories.
+     * @param components The alias for the components' directory.
+     * @param utils The alias for the utils directory.
+     * @param ui The alias for UI components.
+     */
     @Serializable
     class Aliases(
-        override val components: String,
-        override val utils: String,
+        val components: String,
+        val utils: String,
         val ui: String? = null
     ) : Config.Aliases()
 }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidSource.kt
@@ -15,12 +15,17 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.nio.file.NoSuchFileException
 
-class SolidSource(project: Project) : Source<SolidConfig>(project, SolidConfig.serializer()) {
+class SolidSource(
+    project: Project,
+    configName: String = "components.json"
+) : Source<SolidConfig>(project, SolidConfig.serializer()) {
     companion object {
         private val log = logger<SolidSource>()
     }
 
     override var framework = "Solid"
+
+    override val configFile = configName
 
     override fun usesDirectoriesForComponents() = false
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SolidUISource.kt
@@ -1,0 +1,87 @@
+package com.github.warningimhack3r.intellijshadcnplugin.backend.sources.impl
+
+import com.github.warningimhack3r.intellijshadcnplugin.backend.helpers.FileManager
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.Source
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.config.SolidUIConfig
+import com.github.warningimhack3r.intellijshadcnplugin.backend.sources.replacement.ImportsPackagesReplacementVisitor
+import com.github.warningimhack3r.intellijshadcnplugin.notifications.NotificationManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.nio.file.NoSuchFileException
+
+class SolidUISource(project: Project) : Source<SolidUIConfig>(project, SolidUIConfig.serializer()) {
+    companion object {
+        private val log = logger<SolidUISource>()
+        private var isJsUnsupportedNotified = false
+    }
+
+    override var framework = "Solid"
+
+    override val configFile = "ui.config.json"
+
+    override fun getURLPathForComponent(componentName: String) = "registry/ui/$componentName.json"
+
+    override fun getLocalPathForComponents() = getLocalConfig().componentDir
+
+    override fun usesDirectoriesForComponents() = false
+
+    override fun resolveAlias(alias: String): String {
+        if (!alias.startsWith("$") && !alias.startsWith("@") && !alias.startsWith("~")) {
+            log.warn("Alias $alias does not start with $, @ or ~, returning it as-is")
+            return alias
+        }
+        val configFile = if (getLocalConfig().tsx) "tsconfig.json" else "jsconfig.json"
+        val tsConfig = FileManager(project).getFileContentsAtPath(configFile)
+            ?: throw NoSuchFileException("$configFile not found")
+        val aliasPath = Json.parseToJsonElement(tsConfig)
+            .jsonObject["compilerOptions"]
+            ?.jsonObject?.get("paths")
+            ?.jsonObject?.get("${alias.substringBefore("/")}/*")
+            ?.jsonArray?.get(0)
+            ?.jsonPrimitive?.content ?: throw Exception("Cannot find alias $alias in $tsConfig")
+        return aliasPath.replace(Regex("^\\.+/"), "")
+            .replace(Regex("\\*$"), alias.substringAfter("/")).also {
+                log.debug("Resolved alias $alias to $it")
+            }
+    }
+
+    override fun adaptFileExtensionToConfig(extension: String): String {
+        return if (!getLocalConfig().tsx) {
+            extension
+                .replace(Regex("\\.tsx$"), ".ts")
+                .replace(Regex("\\.jsx$"), ".js")
+        } else extension
+    }
+
+    override fun adaptFileToConfig(file: PsiFile) {
+        val config = getLocalConfig()
+
+        if (!config.tsx) {
+            if (!isJsUnsupportedNotified) {
+                NotificationManager(project).sendNotification(
+                    "TypeScript option for Solid",
+                    "You have TypeScript disabled in your shadcn/ui config. This feature is not supported yet. Please install/update your components with the CLI for now.",
+                    NotificationType.WARNING
+                )
+                isJsUnsupportedNotified = true
+            }
+            // TODO: detype Solid file
+        }
+
+        val importsPackagesReplacementVisitor = ImportsPackagesReplacementVisitor(project)
+        runReadAction { file.accept(importsPackagesReplacementVisitor) }
+        importsPackagesReplacementVisitor.replaceImports visitor@{ `package` ->
+            val pathAlias = config.aliases.path.replace("/*", "")
+            return@visitor `package`
+                .replace("~/registry/ui", "$pathAlias/components/ui")
+                .replace("~/lib/utils", "$pathAlias/lib/utils")
+        }
+    }
+}


### PR DESCRIPTION
Both [shadcn-solid](https://shadcn-solid.com) and [solid-ui](https://www.solid-ui.com) have (greatly) diverged from the original [shadcn/ui](https://ui.shadcn.com) implementation since their initial support in this plugin.

Consequently, I have to make significant changes to make my code even more flexible to keep other framework implementations working and add support for those two.

## Evolving list of divergences

### Common
- No longer support the `style` value in the config
- No longer support the `baseColor` value in the config

### Changes in shadcn-solid
- Adds support for UnoCSS (Tailwind is now optional as a result)

### Changes in solid-ui
- Renames its config from `components.json` to `ui.config.json`
- No longer supports aliases in the config except for a custom `path` one