### PR TITLE
Fix package installation for yarn, add support for `bun.lock`

### DIFF
--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
@@ -30,10 +30,10 @@ class DependencyManager(private val project: Project) {
         BUN("bun");
 
         fun getLockFileName() = when (this) {
-            NPM -> "package-lock.json"
-            PNPM -> "pnpm-lock.yaml"
-            YARN -> "yarn.lock"
-            BUN -> "bun.lockb"
+            NPM -> listOf("package-lock.json")
+            PNPM -> listOf("pnpm-lock.yaml")
+            YARN -> listOf("yarn.lock")
+            BUN -> listOf("bun.lockb", "bun.lock")
         }
 
         fun getInstallCommand() = when (this) {
@@ -44,8 +44,10 @@ class DependencyManager(private val project: Project) {
 
     private fun getPackageManager(): PackageManager? {
         val fileManager = FileManager.getInstance(project)
-        return enumValues<PackageManager>().firstOrNull {
-            fileManager.getVirtualFilesByName(it.getLockFileName()).isNotEmpty()
+        return enumValues<PackageManager>().firstOrNull { packageManager ->
+            packageManager.getLockFileName().any { lockFile ->
+                fileManager.getVirtualFilesByName(lockFile).isNotEmpty()
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
@@ -44,7 +44,7 @@ class DependencyManager(private val project: Project) {
 
     private fun getPackageManager(): PackageManager? {
         val fileManager = FileManager.getInstance(project)
-        return PackageManager.entries.firstOrNull {
+        return enumValues<PackageManager>().firstOrNull {
             fileManager.getVirtualFilesByName(it.getLockFileName()).isNotEmpty()
         }
     }

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/helpers/DependencyManager.kt
@@ -35,12 +35,22 @@ class DependencyManager(private val project: Project) {
         }.values.firstOrNull()
     }
 
+    private fun getInstallCommand(packageManager: String): String {
+        return when (packageManager) {
+            "npm" -> "i"
+            "pnpm" -> "add"
+            "yarn" -> "add"
+            "bun" -> "add"
+            else -> throw IllegalArgumentException("Unknown package manager: $packageManager")
+        }
+    }
+
     fun installDependencies(dependencyNames: List<String>, installationType: InstallationType = InstallationType.PROD) {
         getPackageManager()?.let { packageManager ->
             // install the dependency
             val command = listOfNotNull(
                 packageManager,
-                "i",
+                getInstallCommand(packageManager),
                 if (installationType == InstallationType.DEV) "-D" else null,
                 *dependencyNames.toTypedArray()
             ).toTypedArray()


### PR DESCRIPTION
I added a new private function between `getPackageManager` and `installDependency` to get the installation command based on the package manager.

I made 4 blank next.js shadcn/ui projects to test it, one for each package manager and install and dev install work for all package managers now.

The install command is hardcoded to `i` in the current version which only works for NPM according to documentations of the package managers.