### PR TITLE
fix: handle scoped npm package aliases SvelteSource.resolveAlias

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ on:
     branches: [ main ]
   # Trigger the workflow on any pull request
   pull_request:
+  # Allow manual trigger
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
+++ b/src/main/kotlin/com/github/warningimhack3r/intellijshadcnplugin/backend/sources/impl/SvelteSource.kt
@@ -72,14 +72,27 @@ open class SvelteSource(project: Project) : Source<SvelteConfig>(project, Svelte
                 fileManager.getFileContentsAtPath(configFileName)
                     ?: throw NoSuchFileException("Cannot get $configFileName after sync")
         }
-        val aliasPath = parseTsConfig(tsConfig)
+        // Handle scoped package aliases (e.g. @repo/ui/components).
+        // For @-prefixed aliases, the package name includes a slash (@scope/name),
+        // so we split into at most 3 parts to correctly separate the prefix from the rest.
+        val (aliasPrefix, suffix) = if (alias.startsWith("@")) {
+            val parts = alias.split("/", limit = 3)
+            val prefix = if (parts.size >= 2) "${parts[0]}/${parts[1]}" else alias
+            val rest = if (parts.size >= 3) parts[2] else ""
+            prefix to rest
+        } else {
+            alias.substringBefore("/") to alias.substringAfter("/", "")
+        }
+
+        val paths = parseTsConfig(tsConfig)
             .asJsonObject?.get("compilerOptions")
             ?.asJsonObject?.get("paths")
-            ?.asJsonObject?.get(alias.substringBefore("/"))
+
+        val aliasPath = (paths?.asJsonObject?.get(aliasPrefix)
+            ?: paths?.asJsonObject?.get("$aliasPrefix/*"))
             ?.asJsonArray?.get(0)
             ?.asJsonPrimitive?.content ?: throw Exception("Cannot find alias $alias in $tsConfig")
-        val normalized = aliasPath.replace(Regex("^\\.+/"), "")
-        val suffix = alias.substringAfter("/", "")
+        val normalized = aliasPath.replace(Regex("^\\.+/"), "").removeSuffix("/*")
         val resolved = if (suffix.isEmpty()) normalized else "$normalized/$suffix"
         return resolved.also { log.debug("Resolved alias $alias to $it") }
     }


### PR DESCRIPTION
When using something like turborepo in my case, you end up with scoped paths like @repo/yourPackageName/components/
The previous path resolver always cut this of at the first slash, which usually works if you have something like $lib/components/

We now handle scoped namespaces separate,
Not sure if that is also an issue with other frameworks, but this solves it for Svelte.

PS: The workflow change is kinda forced, since I needed to push again after enabling actions to trigger a CI build.
So I was like, why not add a dispatch trigger while am at it, hope you dont mind.